### PR TITLE
vcfeval_flavors

### DIFF
--- a/test/resources/system/test_vcfeval_flavors/004777-UGAv3-20.pred.chr1_1-1000000.vcf.gz
+++ b/test/resources/system/test_vcfeval_flavors/004777-UGAv3-20.pred.chr1_1-1000000.vcf.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29a67ab1fe0ccb3b65afff406808e2076ece76ed621c5b1e1da7b74d39cc9df1
+size 151029

--- a/test/resources/system/test_vcfeval_flavors/004777-UGAv3-20.pred.chr1_1-1000000.vcf.gz.tbi
+++ b/test/resources/system/test_vcfeval_flavors/004777-UGAv3-20.pred.chr1_1-1000000.vcf.gz.tbi
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c0f2bd0f5d7f054ce214e95a88c02d6b93ef16bf816138a3b8ae632f12d8861
+size 611

--- a/test/resources/system/test_vcfeval_flavors/HG001_GRCh38_1_22_v4.2.1_benchmark.chr1_1-1000000.bed
+++ b/test/resources/system/test_vcfeval_flavors/HG001_GRCh38_1_22_v4.2.1_benchmark.chr1_1-1000000.bed
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6cf354472ccc291e72a4dda52508789295679decf31fed60c6dcbec87b07648
+size 2888

--- a/test/resources/system/test_vcfeval_flavors/HG001_GRCh38_1_22_v4.2.1_benchmark.chr1_1-1000000.vcf.gz
+++ b/test/resources/system/test_vcfeval_flavors/HG001_GRCh38_1_22_v4.2.1_benchmark.chr1_1-1000000.vcf.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4aaed543be55a11fbb8c9834451bd10f18e05e20aa75bbb71cdadf859e7100b5
+size 20745

--- a/test/resources/system/test_vcfeval_flavors/HG001_GRCh38_1_22_v4.2.1_benchmark.chr1_1-1000000.vcf.gz.tbi
+++ b/test/resources/system/test_vcfeval_flavors/HG001_GRCh38_1_22_v4.2.1_benchmark.chr1_1-1000000.vcf.gz.tbi
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ab7c6ae0dde53c6d92cab76bea29c9325c81cd626bc7e72688d18e71c72dea8
+size 257

--- a/test/resources/system/test_vcfeval_flavors/dv.pred.chr1_1-1000000.vcf.gz
+++ b/test/resources/system/test_vcfeval_flavors/dv.pred.chr1_1-1000000.vcf.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3eedb56b1e577702bd00f8d7a5de04b09c18152262e882656935a56b0124b2d1
+size 121489

--- a/test/resources/system/test_vcfeval_flavors/dv.pred.chr1_1-1000000.vcf.gz.tbi
+++ b/test/resources/system/test_vcfeval_flavors/dv.pred.chr1_1-1000000.vcf.gz.tbi
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5684f65b4dc9b21dfb09d129b356cc401c329dbf5b48de22dbe6cd50872f08a5
+size 598

--- a/test/system/test_vcfeval_flavors.py
+++ b/test/system/test_vcfeval_flavors.py
@@ -1,0 +1,51 @@
+import pytest
+
+from test import get_resource_dir, test_dir
+from ugvc.pipelines import vcfeval_flavors
+
+
+class TestVcfEvalFlavors:
+    inputs_dir = get_resource_dir(__file__)
+    general_inputs_dir = f'{test_dir}/resources/general/chr1_head'
+
+    @pytest.mark.parametrize('penalty,expected_tp, expected_fp, expected_fn, expected_precision, expected_recall',
+                             [
+                                 [2, 24, 6, 7, 80.0, 77.42],
+                                 [1, 24, 5.5, 6.5, 81.36, 78.69],
+                                 [0, 24, 5, 6, 82.76, 80.0],
+                                 [-1, 25, 5, 6, 83.33, 80.65],
+                             ])
+    def test_penalty(self, tmpdir,
+                     penalty,
+                     expected_tp,
+                     expected_fp,
+                     expected_fn,
+                     expected_precision,
+                     expected_recall):
+        """
+        We've implemented two indel allele error:
+          (chr1    805514  .       AC      A)
+          (chr1	842922	rs58115377	C	CCTT)
+        And one indel genotype error:
+          (chr1    814583  rs56197012      T       TAA )
+        These should affect the evaluation depending on the penalty score
+        """
+        out_dir = f'{tmpdir}/test_penalty_{penalty}'
+        result = vcfeval_flavors.run(
+            [
+                'vcfeval_flavors',
+                '-c', f'{self.inputs_dir}/004777-UGAv3-20.pred.chr1_1-1000000.vcf.gz',
+                '-b', f'{self.inputs_dir}/HG001_GRCh38_1_22_v4.2.1_benchmark.chr1_1-1000000.vcf.gz',
+                '-e', f'{self.inputs_dir}/HG001_GRCh38_1_22_v4.2.1_benchmark.chr1_1-1000000.bed',
+                '-o', out_dir,
+                '-t', f'{self.general_inputs_dir}/Homo_sapiens_assembly38.fasta.sdf',
+                '-p', str(penalty)
+            ]
+        )
+        vtype, tp, fp, fn, precision, recall, f1 = result[1].split()
+        assert vtype == 'indels'
+        assert float(tp) == expected_tp
+        assert float(fp) == expected_fp
+        assert float(fn) == expected_fn
+        assert float(precision) == expected_precision
+        assert float(recall) == expected_recall

--- a/ugvc/__main__.py
+++ b/ugvc/__main__.py
@@ -20,7 +20,8 @@ from ugvc.pipelines import (
     run_comparison_pipeline,
     train_models_pipeline,
     convert_haploid_regions,
-    correct_genotypes_by_imputation
+    correct_genotypes_by_imputation,
+    vcfeval_flavors
 )
 from ugvc.pipelines.mrd import (
     collect_coverage_per_motif,
@@ -56,7 +57,8 @@ modules = [
     train_models_pipeline,
     filter_sample_cnvs,
     convert_haploid_regions,
-    correct_genotypes_by_imputation
+    correct_genotypes_by_imputation,
+    vcfeval_flavors
 ]
 
 sec_modules = [correct_systematic_errors, sec_training, sec_validation]

--- a/ugvc/pipelines/vcfeval_flavors.py
+++ b/ugvc/pipelines/vcfeval_flavors.py
@@ -1,0 +1,113 @@
+#!/env/python
+
+# Copyright 2022 Ultima Genomics Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+# DESCRIPTION
+#    Compare vcf file to ground-truth in alternative manner
+# CHANGELOG in reverse chronological order
+
+from __future__ import annotations
+import argparse
+import subprocess
+import json
+import pysam
+
+from simppl.simple_pipeline import SimplePipeline
+from ugvc.utils.stats_utils import get_precision, get_recall, get_f1
+
+
+def get_parser(argv: list[str]):
+    ap = argparse.ArgumentParser(prog='vcfeval_flavors.py', description=run.__doc__)
+    ap.add_argument('-b', '--baseline',
+                        help="VCF file containing baseline variants", type=str, required=True)
+    ap.add_argument('-c', '--calls',
+                        help="VCF file containing called variants--output_prefix", type=str, required=True)
+    ap.add_argument('-e', '--evaluation_regions',
+                        help='if set, evaluate within regions contained in the supplied BED file, '
+                             'allowing transborder matches. To be used for truth-set', type=str)
+    ap.add_argument('-o', '--output',
+                        help='directory for output', type=str, required=True)
+    ap.add_argument('-t', '--template',
+                        help='SDF of the reference genome the variants are called against')
+    ap.add_argument('-p', '--allele_and_genotype_error_penalty',
+                        type=int,
+                        choices=[2, 1, 0, -1],
+                        default=0,
+                        help="-p 2: usual vcfeval, penalizes twice each wrong-allele/genotype errror\n" \
+                             "-p 1: penalize wrong-allele/genotype only once (remove 0.5 of such fps and fns)\n" \
+                             "-p 0: don't penalize wrong-allele/genotype (remove completely such fps and fns)\n" \
+                             "-p -1: don't penalize, and also reward a tp for calling wrong-allele/genotype\n")
+    return ap
+    return args
+
+def count_vcf_lines(vcf_file):
+    v_iter = pysam.VariantFile(vcf_file)
+    count = 0
+    for variant in v_iter:
+        count += 1
+    return count
+
+def run(argv: list[str]):
+    """Evaluate VCF against baseline, giving alternative penalty to wrong-alleles and genotype errors"""
+    parser = get_parser(argv)
+    SimplePipeline.add_parse_args(parser)
+    args = parser.parse_args(argv[1:])
+    sp = SimplePipeline(args.fc, args.lc, args.d)
+    calls = args.calls
+    baseline = args.baseline
+    eval_reg = args.evaluation_regions
+    sdf = args.template
+    out_dir = args.output
+    penalty = args.allele_and_genotype_error_penalty
+    result = []
+    sp.print_and_run(f'rm -rf {out_dir}')
+    sp.print_and_run(f'rtg vcfeval -b {baseline} -c {calls} -e {eval_reg} -t {sdf} -o {out_dir}')
+    sp.print_and_run(f'bedtools intersect -a {calls} -b {eval_reg} -header > {out_dir}/input_in_hcr.vcf')
+    sp.print_and_run(f'bcftools view -f PASS {out_dir}/input_in_hcr.vcf > {out_dir}/input_in_hcr.pass.vcf')
+    sp.print_and_run(f'bedtools intersect -a {baseline} -b {eval_reg} -header > {out_dir}/gtr_in_hcr.vcf')
+    result.append('type tp fp fn precision recall f1')
+    for vt in ['indels', 'snps']:
+        for pref in ['input_in_hcr', 'gtr_in_hcr', 'input_in_hcr.pass']:
+            sp.print_and_run(f'bcftools view {out_dir}/{pref}.vcf --type {vt} > {out_dir}/{pref}.{vt}.vcf')
+        sp.print_and_run(f'bcftools view {baseline} --type {vt} > {out_dir}/gt.{vt}.vcf')
+        for pref in ['fp', 'tp', 'fn']:
+            sp.print_and_run(f'bcftools view {out_dir}/{pref}.vcf.gz --type {vt} > {out_dir}/{pref}.{vt}.vcf')
+        sp.print_and_run(f'bedtools subtract -A -a {out_dir}/fp.{vt}.vcf -b {out_dir}/gt.{vt}.vcf -header >  {out_dir}/fp.{vt}.clean.vcf;')
+        sp.print_and_run(f'bedtools subtract -A -a {out_dir}/fn.{vt}.vcf -b {out_dir}/input_in_hcr.pass.{vt}.vcf -header > {out_dir}/fn.{vt}.clean.vcf')
+
+        tp = count_vcf_lines(f'{out_dir}/tp.{vt}.vcf')
+        fp_clean = count_vcf_lines(f'{out_dir}/fp.{vt}.clean.vcf')
+        fn_clean = count_vcf_lines(f'{out_dir}/fn.{vt}.clean.vcf');
+        fp = count_vcf_lines(f'{out_dir}/fp.{vt}.vcf');
+        fn = count_vcf_lines(f'{out_dir}/fn.{vt}.vcf');
+        allele_and_genotype_fp_errors = fp - fp_clean
+        allele_and_genotype_fn_errors = fn - fn_clean
+
+        if penalty == 1:
+          fp -= allele_and_genotype_fp_errors / 2
+          fn -= allele_and_genotype_fn_errors / 2
+        elif penalty == 0:
+          fp -= allele_and_genotype_fp_errors
+          fn -= allele_and_genotype_fn_errors
+        elif penalty == -1:
+          fp -= allele_and_genotype_fp_errors
+          fn -= allele_and_genotype_fn_errors
+          tp += (allele_and_genotype_fp_errors + allele_and_genotype_fn_errors) / 2
+        precision = get_precision(fp, tp) * 100
+        recall = get_recall(fn, tp) * 100
+        f1 = get_f1(precision / 100, recall / 100)  * 100
+        result.append(f'{vt} {tp} {fp} {fn} {precision:.2f} {recall:.2f} {f1:.2f}')
+    for line in result:
+        print(line)
+


### PR DESCRIPTION
alternative ways to penalize allele and genotype errors in vcfeval
The parameter controlling the penalty is -p (--penalty)
-p 2: usual vcfeval
-p 1: penalize wrong-allele/genotype only once (remove 0.5 of such fps and fns)
-p 0: don't penalize wrong-allele/genotype (remove completely such fps and fns)
-p -1: reward a tp for calling wrong-allele/genotype 