### PR TITLE
use ref with short sha

### DIFF
--- a/.github/workflows/build-vc-docker.yml
+++ b/.github/workflows/build-vc-docker.yml
@@ -35,6 +35,16 @@ jobs:
         with:
           length: 7
 
+      - name: set tag
+        id: set-tag
+        if: ${{ inputs.image-tag == '' }}
+        run: |
+          if [ ${{ github.ref_name }} == 'master' ]; then
+            echo "imageTag=master_${{ steps.short-sha.outputs.sha }}" >>$GITHUB_OUTPUT;
+          else
+            echo "imageTag=test_${{ steps.short-sha.outputs.sha }}" >>$GITHUB_OUTPUT;
+          fi
+          
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v3
         with:
@@ -72,7 +82,7 @@ jobs:
           provenance: false
           push: true
           tags: |
-            ${{ steps.ecr-login.outputs.registry }}/${{ env.IMAGE }}:${{ inputs.image-tag || steps.short-sha.outputs.sha }}
-            us-central1-docker.pkg.dev/ultima-data-307918/ultimagen/${{ env.IMAGE }}:${{ inputs.image-tag || steps.short-sha.outputs.sha }}
+            ${{ steps.ecr-login.outputs.registry }}/${{ env.IMAGE }}:${{ inputs.image-tag || steps.set-tag.outputs.imageTag }}
+            us-central1-docker.pkg.dev/ultima-data-307918/ultimagen/${{ env.IMAGE }}:${{ inputs.image-tag || steps.set-tag.outputs.imageTag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build-vc-docker.yml
+++ b/.github/workflows/build-vc-docker.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v02
+        uses: google-github-actions/auth@v2
         with:
           token_format: access_token
           workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/build-vc-docker.yml
+++ b/.github/workflows/build-vc-docker.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v02
         with:
           token_format: access_token
           workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}


### PR DESCRIPTION
will use image-tag input if set
otherwise, will use test_{commit_sha} for dev branch or master_{commit_sha} for master branch