### PR TITLE
srsnv inference fix pre-filter with == bug

### DIFF
--- a/ugvc/mrd/srsnv_inference_utils.py
+++ b/ugvc/mrd/srsnv_inference_utils.py
@@ -97,7 +97,7 @@ class MLQualAnnotator(VcfAnnotator):
         self.categorical_features_dict = categorical_features_dict
         self.categorical_features_names = list(self.categorical_features_dict.keys())
         if pre_filter:
-            self.pre_filter = pre_filter.replace("INFO/", "").replace("&&", "&").replace("=", "==")
+            self.pre_filter = pre_filter.replace("INFO/", "").replace("&&", "&")
             logger.debug(f"Using pre-filter query: {self.pre_filter} (original: {pre_filter})")
         else:
             self.pre_filter = None


### PR DESCRIPTION
When pre-filter had a condition with == (like `X_MAPQ==60`) the pre-filter would be changed to ==== (e.g. `X_MAPQ====60`) before filtering the pandas dataframe, and an exception would be thrown. This PR fixed this issue. 