### PR TITLE
Gat/methylationqc upgrade gatk

### DIFF
--- a/Dockerfile.methylationqc
+++ b/Dockerfile.methylationqc
@@ -85,7 +85,7 @@ RUN apt-get update && \
 WORKDIR /app/VariantCalling
 COPY --from=build /opt/venv /opt/venv
 COPY --from=build /app/bin /app/bin
-COPY --from=build /app/gatk/gatk-${GATK_VERSION} /app/gatk
+COPY --from=build /app/gatk/gatk-4.6.0.0 /app/gatk
 COPY . .
 COPY ./setup/methylationqc/pyproject.toml ./pyproject.toml
 COPY ./setup/methylationqc/data/meth_hg38-chr20_Lambda_pUC19.interval_list /app/interval_list/meth_hg38-chr20_Lambda_pUC19.interval_list

--- a/Dockerfile.methylationqc
+++ b/Dockerfile.methylationqc
@@ -52,9 +52,9 @@ RUN git clone https://github.com/dpryan79/MethylDackel.git && \
     make install prefix=/app/bin/
 
 WORKDIR /app/gatk
-RUN wget -O gatk.zip  https://github.com/broadinstitute/gatk/releases/download/4.5.0.0/gatk-4.5.0.0.zip && \
+RUN export GATK_VERSION="4.6.0.0" && wget -O gatk.zip https://github.com/broadinstitute/gatk/releases/download/${GATK_VERSION}/gatk-${GATK_VERSION}.zip && \
     unzip  gatk.zip && \
-    cd gatk-4.5.0.0
+    cd gatk-${GATK_VERSION}
 
 
 ################################################
@@ -85,7 +85,7 @@ RUN apt-get update && \
 WORKDIR /app/VariantCalling
 COPY --from=build /opt/venv /opt/venv
 COPY --from=build /app/bin /app/bin
-COPY --from=build /app/gatk/gatk-4.5.0.0 /app/gatk
+COPY --from=build /app/gatk/gatk-${GATK_VERSION} /app/gatk
 COPY . .
 COPY ./setup/methylationqc/pyproject.toml ./pyproject.toml
 COPY ./setup/methylationqc/data/meth_hg38-chr20_Lambda_pUC19.interval_list /app/interval_list/meth_hg38-chr20_Lambda_pUC19.interval_list

--- a/setup/methylationqc/pyproject.toml
+++ b/setup/methylationqc/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "methylationqc"
-version = "1.0.12"
+version = "1.0.13"
 description = ""
 authors = ["Gat Krieger <gat.krieger@ultimagen.com>"]
 # readme = "README.md"


### PR DESCRIPTION
Hi @itamark-ug 
I had to upgrade gatk following an error in PrintReads found in the prev version https://ultimagen.atlassian.net/jira/software/projects/BIOIN/boards/30?selectedIssue=BIOIN-1710
Is there an option to test the new docker?
I'm also testing the option of removing the PrintReads task from the pipeline,