### PR TITLE
ugbio_utils will not be check out in detached head state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI Workflow
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+        # Checkout the repository with submodules
+        - name: Checkout repository
+          uses: actions/checkout@v3
+          with:
+            submodules: recursive # Ensures submodules are fetched
+
+        # Run the submodule validation script
+
+        - name: Validate submodule state
+          run: |
+            cd ugbio_utils
+            git fetch origin main
+            LATEST_MASTER_COMMIT=$(git rev-parse origin/main)
+            CURRENT_SUBMODULE_COMMIT=$(git rev-parse HEAD)
+            if [ "$LATEST_MASTER_COMMIT" != "$CURRENT_SUBMODULE_COMMIT" ]; then
+                echo "Submodule ugbio_utils is not up-to-date with the master branch."
+                echo "Expected: $LATEST_MASTER_COMMIT, Found: $CURRENT_SUBMODULE_COMMIT"
+                exit 1
+            fi
+            echo "Submodule is up-to-date."

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,4 @@
 [submodule "ugbio_utils"]
 	path = ugbio_utils
 	url = git@github.com:Ultimagen/ugbio-utils.git
+	update = merge


### PR DESCRIPTION
The goal of this somewhat experimental PR is to prevent situation where the master of VariantCalling does not point to the head of the main of `ugbio_utils`. 

There are two things that I implemented
1. CI workflow that requires that PR into master of VariantCalling contains `ugbio_utils` pointing to the head of the main. 
2. ugbio_utils will by default checkout into 'main" rather than an annoying "detached HEAD" state. 

The magic from here: 
**[https://stackoverflow.com/questions/18770545/why-is-my-git-submodule-head-detached-from-master/55570998#55570998](https://stackoverflow.com/questions/18770545/why-is-my-git-submodule-head-detached-from-master/55570998#55570998)**