### PR TITLE
[BIOIN-2035] remove ugbio-utils tests from ci

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -64,8 +64,3 @@ jobs:
         run: |
           conda activate genomics.py3
           python -m pytest --durations=0 test
-      - name: Test ugbio_utils with pytest
-        shell: bash -l {0}
-        run: |
-          conda activate genomics.py3
-          python -m pytest --ignore-glob='ugbio_utils/src/single_cell/*' --ignore-glob='ugbio_utils/src/omics/*' --ignore-glob='ugbio_utils/src/featuremap/tests/system/test_featuremap_xgb_training.py' --ignore-glob='ugbio_utils/src/filtering/*' ugbio_utils/src/*/tests


### PR DESCRIPTION
replaced in [this](https://github.com/Ultimagen/ugbio-utils/pull/107) pr by inner ugbio-utils-bioinfo-CI