### PR TITLE
[BIOIN-2494] Fixed a critical bug in refine_denovo script 

### DIFF
--- a/.github/workflows/build-vc-docker.yml
+++ b/.github/workflows/build-vc-docker.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
-          root-reserve-mb: 512
+          root-reserve-mb: 4096
           swap-size-mb: 1024
           remove-dotnet: 'true'
           build-mount-path: /var/lib/docker/

--- a/.github/workflows/build-vc-docker.yml
+++ b/.github/workflows/build-vc-docker.yml
@@ -27,14 +27,14 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - name: Make space
-      # As suggested here: https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
-        run: |
-          df -h
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf "/usr/local/share/boost"
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          root-reserve-mb: 512
+          swap-size-mb: 1024
+          remove-dotnet: 'true'
+      - name: Check space
+        run:
           df -h
 
       - uses: actions/checkout@v4

--- a/.github/workflows/build-vc-docker.yml
+++ b/.github/workflows/build-vc-docker.yml
@@ -33,6 +33,13 @@ jobs:
           root-reserve-mb: 512
           swap-size-mb: 1024
           remove-dotnet: 'true'
+          build-mount-path: /var/lib/docker/
+          remove-android: 'true'
+          remove-haskell: 'true'
+          remove-codeql: 'true'
+          remove-docker-images: 'true'
+      - name: Restart docker
+        run: sudo service docker restart
       - name: Check space
         run:
           df -h

--- a/test/unit/joint/test_denovo_refinement.py
+++ b/test/unit/joint/test_denovo_refinement.py
@@ -32,6 +32,21 @@ def test_add_parental_qualities_to_denovo_vcf():
     assert df.equals(expected)
 
 
+def test_add_parental_qualities_to_denovo_vcf_refcalls_removed():
+    datadir = get_resource_dir(__file__)
+    denovo_vcf = pjoin(datadir, "denovo.vcf.gz")
+    parental_vcf_df = pd.DataFrame(pd.read_hdf(pjoin(datadir, "parental_vcf_df.h5"), key="df"))
+    parental_vcf_df.rename(
+        {"sample1-mother": "CL10370-mother", "sample1-father": "CL10370-father"}, axis=1, level=0, inplace=True
+    )
+    parental_vcf_df.loc[parental_vcf_df["CL10370-mother", "filter"] == "RefCall", "qual"] = pd.NA
+    parental_vcf_df.loc[parental_vcf_df["CL10370-father", "filter"] == "RefCall", "qual"] = pd.NA
+
+    df = add_parental_qualities_to_denovo_vcf(denovo_vcf, parental_vcf_df)
+    expected = pd.read_hdf(pjoin(datadir, "denovo_vcf_with_qual.h5"), key="df")
+    assert df.equals(expected)
+
+
 def test_write_recalibrated_vcf(tmpdir):
     datadir = get_resource_dir(__file__)
     recal_df = pd.DataFrame(pd.read_hdf(pjoin(datadir, "denovo_vcf_with_qual.h5"), key="df"))

--- a/test/unit/joint/test_denovo_refinement.py
+++ b/test/unit/joint/test_denovo_refinement.py
@@ -1,6 +1,7 @@
 from os.path import join as pjoin
 from test import get_resource_dir
 
+import numpy as np
 import pandas as pd
 import pysam
 
@@ -39,12 +40,13 @@ def test_add_parental_qualities_to_denovo_vcf_refcalls_removed():
     parental_vcf_df.rename(
         {"sample1-mother": "CL10370-mother", "sample1-father": "CL10370-father"}, axis=1, level=0, inplace=True
     )
-    parental_vcf_df.loc[parental_vcf_df["CL10370-mother", "filter"] == "RefCall", "qual"] = pd.NA
-    parental_vcf_df.loc[parental_vcf_df["CL10370-father", "filter"] == "RefCall", "qual"] = pd.NA
+    df1 = add_parental_qualities_to_denovo_vcf(denovo_vcf, parental_vcf_df)
 
-    df = add_parental_qualities_to_denovo_vcf(denovo_vcf, parental_vcf_df)
-    expected = pd.read_hdf(pjoin(datadir, "denovo_vcf_with_qual.h5"), key="df")
-    assert df.equals(expected)
+    parental_vcf_df.loc[parental_vcf_df["CL10370-mother", "filter"] == "RefCall", ("CL10370-mother", "qual")] = np.nan
+    parental_vcf_df.loc[parental_vcf_df["CL10370-father", "filter"] == "RefCall", ("CL10370-father", "qual")] = np.nan
+
+    df2 = add_parental_qualities_to_denovo_vcf(denovo_vcf, parental_vcf_df)
+    assert np.all(df1["pair_qual"] >= df2["pair_qual"])
 
 
 def test_write_recalibrated_vcf(tmpdir):

--- a/ugvc/joint/denovo_refinement.py
+++ b/ugvc/joint/denovo_refinement.py
@@ -66,7 +66,7 @@ def add_parental_qualities_to_denovo_vcf(denovo_vcf: str, parental_vcf_df: pd.Da
         df_denovo_exp.shape[0] > 0
     ), "No denovo calls found in the VCF or no overlap between the de novo vcf and the somatic calls"
     df_denovo_exp["pair_qual"] = df_denovo_exp.apply(
-        lambda x: min(x[x["denovosample"] + "-father"], x[x["denovosample"] + "-mother"]), axis=1
+        lambda x: min(x[x["denovosample"] + "-father"].fillna(0), x[x["denovosample"] + "-mother"].fillna(0)), axis=1
     )
     df_denovo_exp["pair_qual"].fillna(0, inplace=True)
     return df_denovo_exp

--- a/ugvc/joint/denovo_refinement.py
+++ b/ugvc/joint/denovo_refinement.py
@@ -65,8 +65,12 @@ def add_parental_qualities_to_denovo_vcf(denovo_vcf: str, parental_vcf_df: pd.Da
     assert (
         df_denovo_exp.shape[0] > 0
     ), "No denovo calls found in the VCF or no overlap between the de novo vcf and the somatic calls"
-    df_denovo_exp["pair_qual"] = df_denovo_exp.apply(
-        lambda x: min(x[x["denovosample"] + "-father"].fillna(0), x[x["denovosample"] + "-mother"].fillna(0)), axis=1
+
+    paternal_qual = df_denovo_exp.apply(lambda x: x[x["denovosample"] + "-father"], axis=1).fillna(0)
+    maternal_qual = df_denovo_exp.apply(lambda x: x[x["denovosample"] + "-mother"], axis=1).fillna(0)
+
+    df_denovo_exp["pair_qual"] = np.min(
+        pd.concat({"paternal": paternal_qual, "maternal": maternal_qual}, axis=1), axis=1
     )
     df_denovo_exp["pair_qual"].fillna(0, inplace=True)
     return df_denovo_exp

--- a/ugvc/joint/denovo_refinement.py
+++ b/ugvc/joint/denovo_refinement.py
@@ -72,7 +72,6 @@ def add_parental_qualities_to_denovo_vcf(denovo_vcf: str, parental_vcf_df: pd.Da
     df_denovo_exp["pair_qual"] = np.min(
         pd.concat({"paternal": paternal_qual, "maternal": maternal_qual}, axis=1), axis=1
     )
-    df_denovo_exp["pair_qual"].fillna(0, inplace=True)
     return df_denovo_exp
 
 


### PR DESCRIPTION
in case one of the calls was missing in one of the parents (e.g. if RefCalls were filtered out) denovo_refinement script selected the other value rather than filling None with 0. 

Tangentially - fixed the build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Treat missing parental quals as 0 when computing `pair_qual` and add tests; CI uses maximize-build-space and restarts Docker for image build.
> 
> - **Core (denovo refinement)**:
>   - Update `add_parental_qualities_to_denovo_vcf` to compute `pair_qual` using `fillna(0)` for paternal/maternal quals and `np.min` over concatenated columns.
> - **Tests**:
>   - Add `test_add_parental_qualities_to_denovo_vcf_refcalls_removed` validating lower `pair_qual` when RefCalls are removed.
>   - Import `numpy` in `test_denovo_refinement.py`.
> - **CI**:
>   - Replace manual disk cleanup with `easimon/maximize-build-space` in `.github/workflows/build-vc-docker.yml`, restart Docker, and add space check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8372411e9beb7d8118851433831c5ab2e7d74c00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->