### PR TITLE
[BIOIN-2461] Imports updated + fix for filtering in sv_stats_collect

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,12 +46,7 @@ setup(
         "ugvc/pipelines/vcfbed/gvcf_hcr.py",
         "ugvc/pipelines/denovo_recalibrated_qualities.py",
         "ugbio_utils/src/core/ugbio_core/convert_h5_to_json.py",
-        "ugbio_utils/src/cnv/ugbio_cnv/filter_sample_cnvs.py",
-        "ugbio_utils/src/cnv/ugbio_cnv/plot_cnv_results.py",
-        "ugbio_utils/src/cnv/ugbio_cnv/annotate_FREEC_segments.py",
-        "ugbio_utils/src/filtering/ugbio_filtering/filter_variants_pipeline.py",
         "ugvc/pipelines/correct_genotypes_by_imputation.py",
-        "ugbio_utils/src/cnv/ugbio_cnv/run_cnvpytor.py",
     ],
     entry_points={
         "console_scripts": [

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
         "ugvc/pipelines/denovo_recalibrated_qualities.py",
         "ugbio_utils/src/core/ugbio_core/convert_h5_to_json.py",
         "ugbio_utils/src/cnv/ugbio_cnv/filter_sample_cnvs.py",
-        "ugbio_utils/src/cnv/ugbio_cnv/convert_cnv_results_to_vcf.py",
         "ugbio_utils/src/cnv/ugbio_cnv/plot_cnv_results.py",
         "ugbio_utils/src/cnv/ugbio_cnv/annotate_FREEC_segments.py",
         "ugbio_utils/src/filtering/ugbio_filtering/filter_variants_pipeline.py",

--- a/test/unit/joint/test_gvcf_bed.py
+++ b/test/unit/joint/test_gvcf_bed.py
@@ -2,7 +2,7 @@ import filecmp
 from test import get_resource_dir
 
 import pybedtools
-from ugbio_core.filter_bed import count_bases_in_bed_file
+from ugbio_core.bed_utils import BedUtils
 
 from ugvc.joint.gvcf_bed import gvcf_to_bed
 
@@ -17,7 +17,7 @@ def test_gvcf_to_bed_gt(tmpdir):
     assert filecmp.cmp(output_file, f"{inputs_dir}/calls.expected.bed")
     output_file_mrg = str(tmpdir.join("calls.observed.mrg.bed"))
     pybedtools.BedTool(output_file).merge().saveas(output_file_mrg)
-    assert count_bases_in_bed_file(output_file_mrg) == count_bases_in_bed_file(output_file)
+    assert BedUtils().count_bases_in_bed_file(output_file_mrg) == BedUtils().count_bases_in_bed_file(output_file)
 
 
 def test_gvcf_to_bed_lt(tmpdir):
@@ -28,4 +28,4 @@ def test_gvcf_to_bed_lt(tmpdir):
     assert filecmp.cmp(output_file, f"{inputs_dir}/calls.expected.lt.bed")
     output_file_mrg = str(tmpdir.join("calls.observed.mrg.bed"))
     pybedtools.BedTool(output_file).merge(d=-1).saveas(output_file_mrg)
-    assert count_bases_in_bed_file(output_file_mrg) == count_bases_in_bed_file(output_file)
+    assert BedUtils().count_bases_in_bed_file(output_file_mrg) == BedUtils().count_bases_in_bed_file(output_file)

--- a/test/unit/reports/test_sv_stats_collect.py
+++ b/test/unit/reports/test_sv_stats_collect.py
@@ -20,7 +20,7 @@ class TestCollectSizeTypeHistograms:
         1       2000    .       A       <INS>   .       PASS    SVLEN=300;SVTYPE=INS
         1       3000    .       A       <DEL>   .       PASS    SVLEN=-1000;SVTYPE=DEL
         1       4000    .       A       <INS>   .       PASS    SVLEN=700;SVTYPE=INS
-        1       5000    .       A       <DUP>   .       PASS    SVLEN=2000;SVTYPE=DUP
+        1       5000    .       A       <DUP>   .       .       SVLEN=2000;SVTYPE=DUP
         """
 
     def mock_precision_recall_curve(self, gt, predictions, fn_mask, pos_label, min_class_counts_to_output):

--- a/ugvc/__main__.py
+++ b/ugvc/__main__.py
@@ -12,15 +12,6 @@ if path not in sys.path:
     sys.path.insert(0, path)
 
 from ugbio_cloud_utils import cloud_sync
-
-# import pipeline modules implementing run(argv) method
-from ugbio_cnv import (
-    annotate_FREEC_segments,
-    bicseq2_post_processing,
-    filter_sample_cnvs,
-    plot_cnv_results,
-    plot_FREEC_neutral_AF,
-)
 from ugbio_comparison import run_comparison_pipeline
 from ugbio_core import intersect_bed_regions, sorter_to_h5
 from ugbio_core.vcfbed import annotate_contig
@@ -57,14 +48,9 @@ modules = [
     training_prep_pipeline,
     run_comparison_pipeline,
     train_models_pipeline,
-    filter_sample_cnvs,
-    plot_cnv_results,
     convert_haploid_regions,
     correct_genotypes_by_imputation,
     vcfeval_flavors,
-    bicseq2_post_processing,
-    annotate_FREEC_segments,
-    plot_FREEC_neutral_AF,
 ]
 
 sec_modules = [correct_systematic_errors, sec_training, sec_validation]

--- a/ugvc/__main__.py
+++ b/ugvc/__main__.py
@@ -17,7 +17,6 @@ from ugbio_cloud_utils import cloud_sync
 from ugbio_cnv import (
     annotate_FREEC_segments,
     bicseq2_post_processing,
-    convert_cnv_results_to_vcf,
     filter_sample_cnvs,
     plot_cnv_results,
     plot_FREEC_neutral_AF,
@@ -59,7 +58,6 @@ modules = [
     run_comparison_pipeline,
     train_models_pipeline,
     filter_sample_cnvs,
-    convert_cnv_results_to_vcf,
     plot_cnv_results,
     convert_haploid_regions,
     correct_genotypes_by_imputation,

--- a/ugvc/pipelines/run_no_gt_report.py
+++ b/ugvc/pipelines/run_no_gt_report.py
@@ -28,7 +28,7 @@ import subprocess
 import numpy as np
 import pandas as pd
 import sigProfilerPlotting as sigPlt
-import ugbio_core.filter_bed as fb
+import ugbio_core.bed_utils as bu
 import ugbio_core.vcfbed.variant_annotation as annotation
 from SigProfilerAssignment import Analyzer as Analyze
 from SigProfilerMatrixGenerator import install as genInstall
@@ -278,7 +278,7 @@ def run_eval_tables_only(arg_values):
 
 def run_full_analysis(arg_values):
     if arg_values.callable_region is not None:
-        callable_size = fb.count_bases_in_bed_file(arg_values.callable_region)
+        callable_size = bu.BedUtils().count_bases_in_bed_file(arg_values.callable_region)
         callable_size_series = pd.Series(callable_size, index=["callable_size"])
         callable_size_series.to_hdf(f"{arg_values.output_prefix}.h5", key="callable_size")
     eval_tables = variant_eval_statistics(

--- a/ugvc/pipelines/sv_stats_collect.py
+++ b/ugvc/pipelines/sv_stats_collect.py
@@ -33,7 +33,8 @@ def collect_size_type_histograms(svcall_vcf, ignore_filter: bool = False) -> dic
     if ignore_filter:
         vcf_df = vcftools.get_vcf_df(svcall_vcf, custom_info_fields=["SVLEN", "SVTYPE"])
     else:
-        vcf_df = vcftools.get_vcf_df(svcall_vcf, custom_info_fields=["SVLEN", "SVTYPE"]).query("filter=='PASS'")
+        vcf_df = vcftools.get_vcf_df(svcall_vcf, custom_info_fields=["SVLEN", "SVTYPE"])
+        vcf_df = vcf_df.query("(filter=='PASS') | (filter=='') | (filter == '.')")
     vcf_df["svlen"] = vcf_df["svlen"].apply(lambda x: x[0] if isinstance(x, tuple) else x).fillna(0)
     vcf_df["binned_svlens"] = pd.cut(
         vcf_df["svlen"].abs(),

--- a/ugvc/reports/createSVReport.ipynb
+++ b/ugvc/reports/createSVReport.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 41,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-07-25T13:41:08.009132Z",
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 42,
    "metadata": {
     "tags": [
      "parameters"
@@ -37,7 +37,7 @@
    "source": [
     "run_id = \"NA\"\n",
     "pipeline_version = \"NA\"\n",
-    "statistics_file = \"/data/Runs/VariantCalling/work/251204/hg002.cnv.release.stats.pkl\"\n",
+    "statistics_file = \"/data/Runs/VariantCalling/work/250525/dragen.hg19.stats.pkl\"\n",
     "reference_version = \"hg38\"\n",
     "truth_sample_name = \"NA\"\n",
     "h5outfile = \"var_report.h5\"    \n"
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 43,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-07-25T13:41:08.938665Z",
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 44,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -119,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 45,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-07-25T13:41:11.945866Z",
@@ -154,7 +154,7 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>statistics_file</th>\n",
-       "      <td>hg002.cnv.release.stats.pkl</td>\n",
+       "      <td>dragen.hg19.stats.pkl</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>run_id</th>\n",
@@ -181,13 +181,13 @@
        "</div>"
       ],
       "text/plain": [
-       "                                         value\n",
-       "statistics_file    hg002.cnv.release.stats.pkl\n",
-       "run_id                                      NA\n",
-       "reference_version                         hg38\n",
-       "pipeline_version                            NA\n",
-       "truth_sample_name                           NA\n",
-       "h5outfile                        var_report.h5"
+       "                                   value\n",
+       "statistics_file    dragen.hg19.stats.pkl\n",
+       "run_id                                NA\n",
+       "reference_version                   hg38\n",
+       "pipeline_version                      NA\n",
+       "truth_sample_name                     NA\n",
+       "h5outfile                  var_report.h5"
       ]
      },
      "metadata": {},
@@ -203,7 +203,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [
     {
@@ -262,7 +262,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -273,7 +273,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -282,12 +282,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAGFCAYAAAASI+9IAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAE4ElEQVR4nO3VMQHAMAzAsKz8OWefKbSHhMCfv93dAYCZObcDAHiHKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBAfu8DBwYENNNsAAAAAElFTkSuQmCC",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYcAAAGFCAYAAAAW1j91AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAAA7bUlEQVR4nO3dd3hc1b3u8e+eUa+WZUuyhYtwk2UbY9OMIWBTTWIIYEpiCHYKSYBDCTcn3EM4JEAIkJOEJJACuXSSAIcaiiGUYKopxsbGDVe5qdlWb1P2vn9sjYrHRbJmtGf2vJ/n0aPRaDRaezSad9b67bWWYVmWhYiISDcepxsgIiKxR+EgIiJhFA4iIhJG4SAiImEUDiIiEkbhICIiYRQOIiISRuEgIiJhFA4iIhJG4SAiImEUDiIiEkbhICIiYRQOIiISRuEgIiJhFA4iIhJG4SAiImEUDiIiEkbhICIiYRQOIiISRuEgIiJhFA4iIhJG4SAiImEUDiIiEkbhICIiYRQOIiISRuEgcgCzZs3iuuuuA2DhwoUYhoFhGHi93s7LoY+UlBTmzJmDYRg8//zz1NXVdV5fXl7Odddd1/m9c889l7Fjx4bdh2EYJCUlUVhYyOmnn86DDz6IaZrOPgiSkBQOIn0wZ84cKioquP/++wEYN24cKSkpGIaBaZrU1dXt8+duvvnmsOtM02TIkCGMGjWKOXPmcMQRR5CWlsb8+fNZtGgRs2fP5tprr2Xu3LkEAoFoHpZIGIWDSB+kpqZSVFREfn4+AGVlZVx77bVYlsXMmTNpaGgAoL6+vvNnzj//fB5//HF27drVeZ3f76eiogKfz8eHH35IYWEhJSUlXHrppbz++utMnz6dG2+8kRdeeIFFixbx8MMPD+hxiigcRPqprKwMj8eDYRisX78egOzs7M7vT548mblz5/L+++8DUFlZyXvvvYdlWZxwwgkMGzas87bp6en4/f7Or0855RSmTp3Ks88+O0BHI2JLcroBIvHspZdeYtGiRZimyTvvvENmZiaBQADLsnrc7o477mDy5MkAXHvttaSkpDB8+HBSUlI6b1NbW8t7773Hqaee2uNnS0tLWbFiRfQPRqQb9RxE+mH27NnceuutJCUlUVJSwjnnnAPAc8891+N2ZWVlTJw4EYCzzz6bpqYmGhoaeOmll8jKyuKxxx7jnXfe4aSTTuKee+7p8bOWZWEYxsAckEgHhYPIAeTk5PSoH4TU1dWRnJxMZmYmhYWFmKZJWVkZjz32GADPPPMMLS0tPX6mrKwMsIvY06ZNY/fu3Rx++OEsX76c8847j7PPPptnn32WgoKCHj+3Zs0aSkpKonSEIvumcBA5gNLSUj799NOw6z/55BNycnIAWL16NaZpMm/evM7TUYPBIL///e87b29ZFmvXrgXg8ccfp7i4mIKCAjZs2MCzzz5LVlYWHk/4v+Nbb73FypUrmTdvXpSOUGTfDGvvwVER6bRlyxbKysr49re/zbZt26irq+Oss87illtuYdKkSTQ2NlJeXo5pmixbtow///nP/OlPf8Lr9eLxePD7/Vx55ZUAPPTQQ7S2tpKRkYFpmhQXFzNo0CCWL1/O1KlTKSgo4KGHHiIYDFJVVcWrr77KHXfcwaxZs3j++efxer0OPxqSSBQOIgexdOlSfvrTn7J48WLa2toA8Hg8pKSkdH4N9hlKpaWl3HDDDfh8Pr7zne/Q1tZGZmYmJ554IrfffjtHH300l156KY8//jhjxoxh8uTJzJ8/n2984xudReykpCTy8vKYOnUq8+fPZ8GCBfvsVYhEk8JBRETC6O2IiIiEUTiIiEgYhYOIiIRROIiISBiFg4iIhFE4iIhIGIWDiIiEUTiIiEgYhYOIiIRROIiISBht9iOu1h6waPNb+IMW/iD4gl2X/UELvwlB08KyIMUL00ak2j/XCqnpHXfS1gpp9hcrmr/kiMzx9vUBH/iaISUDklIdODqR6FE4SNwKmhaNbRaN7SYtPotmn9Xx2f66xWcR7MPKYRnJXeGwZwcMGws01MOG9TD9aHb763ijfgkGBlMyx0Htdvj4b/YPe7yQnAGpmZAxCDLz7Y+swfbnlIyIH79INCkcJOYFTYuGNov6VpO6jo/6VpOGdvsdfzR0brxmWZBk/5sErSAAaZ6OrT39rV0/YAahvdH+aKgMv8PkdMjK7xYa+ZA5GDIGg3evf0PL6tYAEWcoHCTmNLSZ1DQFqWk0qWkyqWszoxYC+2OEqnGWBR37KPg7wiE1FA6+ln385H74W+2eRu32vX8TZA+FwSMgbyQMHgnpOf1rvEgEKBxkQO29H3LQtKhp6giDjs/tAQcb2KGziabZ2XMIWHbDUo2OcGhvisBvsqCx2v4oX2pflT7IDonQR1Z+BH6PSN8oHGRAGYZBfavJzvogO+qDVDUGCZpOt2of9jGsFNh7WCki4bAPrXWwow52rLC/Tsm0exahsMgp0rCTRJ3CQaLOH7SobLDDYGd9kKb22N9fqkfPoaMm4Av1HELh0NY4MI3xNUPlWvsD7KJ3YSkMmwj5o7qNgYlEjsJBosIftNhWG2TLngA764OYsZ8HPeyrIO23/EC3YaXWBgdaBrQ3w9al9kdKBhROgGFlkD8atJ2oRIjCQSImYFrsqAuyeXeAHfUxOlzUS51vxrvVHHymn1Qjpatm0lbvTOO687XAtmX2R3I6FE2AookwpMQ+vVbkEGkPaekXy7LYWR9k0+4A22qDBGIoEN58+n5eefz31O+uJDtvKMGAn5bGuh6Xh5dM5JIf3YVhGDz9p5up2fYlTU1NeDxePB4D0wwy6rAR/ODKK9nStpM/3PhrPB4Pp5xyCltWfUZ1fTPHji9mY8UeyqvrOff4ifzlyrmc8JMHeOMXC8jNTOOYH93HG79YwMiCQQN38MlpUDje7lEMHaOhJ+kzhYP0WvczjVp9Jut3BVhfHaDZF3tPoY9ef5r7fn45l/3kblqbGnjynpvwJiVx1qXX8dLDv8ablMT/uftZlr37Cov/+QhX/fJRgq31XH7OsWzZsoXn/vcV/v7UQ9x09dWMPLyE7//oetra2ig8fDg53kw2btzIOceO55ZLZjPtmj8zYmguF54wiRc/Xkd+TgbnHz+R6887gR/e+0/GF+dz/XknOPdgpOfCqKNhxJFdk/E0l0IOQm8npNcMw6CiPsjb69t4+vNWlm/3x2QwALz6j3s56ZzLmPX1hXz85rPMOu/bDC0ezbsvPtp5+YuP/80l1/+KwYXFrFv2ASfOuYhJkybxta99jf+584/MmTOHNevXc+n8+eTm5mJZFsefcxJJSUkEg0EKcjMpHJRF0LRoavVxx4LTmT5mOF/u2MW15xzP+6vL+XTDTq4953hnH4zWelj7Jrz5e1jxItRXKhjkoFRzkIPyBSzW1wT4stpPYxycaRTw+9iydhlfu+z6Hpc9Hi9vPn0/k487laSkFDasXALA5GNP7bwcsnLVMj744AN+cd11/PzOu6ipqSEjJ5NdWyrxeDwkJyfj8RikdEyQO3nyaJpafTy/ZA3XnjODoGlyxZ9e4sFrz8XrjZH3YGYAti23P/JGwOhj7PqEitiyDwoH6aH70FFzu8nqSj/rawIxVUs4mMa63ZjBILmDC3pcTsvIAiB3cAG5+QXUL6m2v+52+bDDDqOmpoZAIEBmZiZX3nwzfr+fa665hiGnj+J3l99B054G5p41h49Wf0rJ9+5mzLDBrN5WTf78O/B6PZiWxdjLf0dTq4/nPljDtfe/wq6GFq6eO4P/OPs4xx6XHmq32R+p2TDqKBg5DVLtx0dDTgIaVpIOodKTYRjUtZq8t7GdZ1e0sqYqvoKhu+4zsQ3D6HGMdgja3+t++d133+XTTz/l7l//Ba/XS0H+YC6ZP5/HH3+cyu07OXvBeUycOJFn//4I//jPCxmSk8HyP1yBgUF+dgZr/3w1v372fZrb/Cz9/Q/51TPvcdZR43n3ru9y6xNvs2LzPtZdclJ7I3z5Nrz1B1j+PDRUKxgEUM8h4YV6CoZhsKc5yIqdfrbWBp1uVr9kD8rH4/VSt7uK0aXTOi+3tzYDULe7ioY9NeQMLgDocbmkpASA0cOnUL27nNtvv50nnnwS0zT50xW/6QwWb84Qpowaym++N4egabJ6Ww1P/d+LGJydTtC0+PqMUvJzMgiYJukpSRQMyuLkyaNZ/MUWjigpcuaBORAzCDtWwo4voHgyjD8ZMvKcbpU4SD2HBBfqKfz7yzZeWtUW98EAkJScwujSaaz6+K0el9d8uphBQ4pY9fFbrPr4LcZOmQHQ43KIYUBKSgrDCwpYvnw5V155JbmFg7jguxczYcIEbv7xNYwqyOOc40p5+I3lAJwxbWzn5XHD8wl2zPzzBezH1B8MEjRjvRtm2SHx9p/gi0XQFqUlQiTmqeeQwJp9Jp9v97NxV4DYLzP3zZxv/gf3/fxySkqnc+yp53ecyprMWZdcw0uP/AYMg7w1n/G3u2+gavsmVnz4Lz6ddhyv/+UNlixZwgkzZvHY3x/kW+eczSeffMJjjz3GsQtPpiCrAK/Xy0N/f4r3fzGf6rom7n7hQ8YNH8ztTy7msX9/jmHApspa1m6rwWMYbKqs5cM1W3nz803ceOFJTj80vWOZUP4pbP8cRh8LY463J9lJwtA8hwTkC1isrPCztsof17OYD8aeBPc76nZVkjO4gKDfR3NjHTmDC2is3YXf386o8VPJyRtC1fZNpKamUlG+HtM0SU5OwTSDpKWkMHb8eL73ve/Rck4G2/6ygkf/+BC3/ej7/MdRWXzzV//LCRNHcuz4Yk6/6RECpskls47g3VXlVNc3M29mWefla8+Zwc3fnO30w3JoktJgzEwoORa8yU63RgaAwiEBhOoKQdNibZWflTv9+OJ/9CjiMpLhgmmZALQ0QEYOsHEDjBmLZVncXfEY3xhyFsNThsKG92Ddv51tsBNSs2DcV2DENHt5Dp3Z5FoaVkoAhmGwoy7AR+W+uFgRNRbs/XpndQy8pUV0L4c41N5k1yI2LYGyM+wlOsSVFA4u1+wz+aTc54pC80DqDIeOC2ZHOHQt152g4RDSUgufPmmv3TRpjr2MuHoRrqJwcJnQEJJpWaytCrB8uy9u5yk4qXOdus65EPaD2BkOTi3XHWsqVsOuzTDxNHvtJnENhYPLGIZBTVOQJZt91LYqFQ7ZPnoOSYaXJKNjGexYWK47Vvhb7TWbdn4BU76m+REuoXkOLhA6pyAQtPi4vJ1Fq9sUDP3UtdlPRzhYZtcmP5aVuDWHA9m1Gd65DzZ9aJ8KC/ZjJXFJPQcXMAyDXU1B3tvUTkOb/hkjoTMcOt4+BTG79o6W/Qv6Yc0bsHMVTJkLuTE4G1x6RT2HOGdaFsu3+1i0pk3BEEF7F6SDVrCr3mCpV3ZQ9RXw/gP2UuHBgNOtkUOgnkMcq2s1eX9TO7ub9WIVaV0bp4XCoduwkqkzv3rFMmHjB1C1Ho66ALKG6IymOKKeQ5xaU+nn5S9aFQxR0tVzsP9FAlaQNE+qfZ2pd8J90lQD7z0AO1crGOKIeg5xxhe0+GBTu+YtRFlXzcG+EOg+rBT0O9OoeBb0wbJnoHYrTDzdnl0tMU3hEAdCcxdqW0wWb1BtYSB0zXMIhUOga3Z0wOdMo9xgyydQtxOmz7P3ttYwU8zSsFIcMAyDTbsCLFrdqmAYaB0vXH4r0NVzUDj0T90OeO//Qc1GBUMMUzjEONO0+GhLO+9tatdMZyfsKxz8rQ42yCV8LfDxP+DLxZoLEaM0rBTDWnwmb29oZ1eTUsExHvv9k98KkB4qSCscIsSC9e/YPYkjz4WUDA0zxRD1HGJMaLZzbYvJK6vbFAxO63ih8ln+rp6Dr8XBBrlQzUZ49692LcIw1JOIEQqHGBIqPO+sD/Lq6lZafPoncVyo52D6u2ZIa+mMyGtrgCWPQvV6BUSMUDjEEMMwWF/t580v2/CrwxAbOk65bLf8XZPgEn257mgJ+u1lwLcu09BSDFDNIYZ8ts3HFxU6hz5mWBZ4O8LB9HXby6HRwUa5nGXBypfsnsT4k51uTUJTOMSAoGnxweZ2Nu/WxLaYk2SHQ4+zlVq1XHfUrX/HfpynzO0c2pOBpXBwWCBo8e/1bVQ0aBwpJiXZ/yIm3f4+bdroZ0Bs/xz8bTD9fPDopWqgKZId5A9avPmlgiGmefd6UbIsra00kKrWwcdPaOKhAxQODvEFLN5Y10ZVo4IhpnXUHKyOPaR1Fo0Ddm+Gjx7X/JIBpnBwQHvA4vV1bdRoDkP8sEKbSasu5Ii6HfDhYzqNeAApHAZYm9/iX2vbtNR2HLEsC0/o1Ert5eCcxipY8rgmIQ4QhcMAavVbvLa2ldoWBUO80XLdMaKpBj75h2oQA0DhMEB8AYs317VR36ox67jRbSJWmsIhdtTthKVPqRcXZQqHARAwLd5a38Ye9RjikoXVNTs60O5sY8S2azMse04nCESRwiHKTMvinQ3tVOuspLhlYnVbrlvhEDMq18DKl51uhWspHKLsg00+ttep+xvPLMvq2j9ap1PGlm3LYO2bTrfClRQOUfRxeTubdmvCVLwzMbuGlXSmTOzZ+IH9ARpmiiCFQ4SF9mNYsdPH2ioFgxuYltltue5mZxsj+7b2TbsXoeW+I0bhEEGh/Ri27A6wfLvOanGLIGZXzUGTsGLXypehcq0CIkIUDhFkGAY1TUHe36SipZsErW7DSlquO3ZZFix7tmtHOekXhUMENbebvL2+naDetLhK0Ap2DStpRdbYZgbhs6dVG4oAhUOEBEyLf69vp9WvZHAbCwuP0fGvor0cYl9rveZARIDCIUI+3NyuSW5uZ1k6lTVe7NoEX75tX1ZIHBKFQz+EzkxaVeHTLm4JQS8ycWXDe1D1peoPh0jh0A+GYVDdGOSzbTozKSHoHWj8Wf48NO9xuhVxSeHQD+0Bi3c3tuv9ZKLQDnDxJ9BuF6i1YGKfKRz64f1N7TT7FA1uZ9AxLBFUOMSlhipY+Yp9Wb2/XlM49FGozrCm0q81kxKEERqz1rvP+LVjBZR/qglyfaBw6CPDMNjdHGTpNm02kii6eg76m8e11f+C2h0qUPeSwqGP/EF7CW5Tbz4SRmc4aLnu+GYG7QK1eoC9onDopdBw0sflPhrblQyJxNMZDm3ONkT6r2UPfLnYvqzhpQNSOPSSYRhsrwuwcZeKkommc3a0X0syuMLmJVp/qRcUDr3kC1os2aIx50TU2XNoVzi4gmXBihe1B/VBKBwOIjSctHSrjxadtpqQOnsOWq7bPRqr7RnUsl8Kh4MwDIOK+iDrazSclKi8Cgd32vAeNFQ73YqYpXA4iEDQ4sMtOkslkXnx2hdatVy3q1gmrPin/VnCKBz2IzSc9Nl2H006OymhdU6C014O7lNfAZuWON2KmKRw2I/QZLd12gdaQtRzcKcvF0PzbqdbEXMUDvvQfU6D+gwCdJwTr+EHVzIDsOIlp1sRcxQO+2AYBpt3B6hp0ouBdNC4tLvt2QrbljvdipiicNiHQNBi6VbNaZBuFA7u9+VirbzbjcJhH1ZW+GnRXtDSnV403K+tAbZ87HQrYobCYS9N7SarK7Qwl+zF1HMiIWx8X/uEd1A4dAgVoT/d6iOoToPsLaBwSAj+NtjwvtOtiAkKhw6GYVDTFGRrrdZbkX0IaCJkwtjyiU5bRuEAdPUalm/Xu0PZDy3XnTjMAKzXst4KB+xeQ1VjkIoG9RpkPzQOnVi2fw6NNQm9rHfCh0NXr0GnrsoB+LRcd0KxLFj3VtflBJTw4WAYBpUNQaoadR67HEB7s9MtkIFW9SXs2ZawvYeEDgf1GqTXtFx3Ylr7pv05AXsPCR0OhmGwsz5ItZbJkINpb3S6BeKE2m2wa3NC9h4SNhxCvYYVO9VrkF5orXe6BeKUzYk5azphw8EwDHY1B6lWrUF6Q+GQuKrXQ/Mep1sx4BI2HADWVGpeg/SCZUFAPczEZdkT4xJMwoZDi8+kfI/mNUhvJF4xUvayfTn4E2uWfMKGw9qqAKb+56U3TA09JryAzw6IBJKQ4RAIWnxZrSEl6SVTPUzBHlpKoFNaEzIcNu4K4NP/u/SWlusWgJZauzidIBIqHEKnr66p0j+79EFQzxfpsPkj+3MC9CASKhxCC+w1tLn/DysRpDOVJGT3FmioTohJcQkVDgAba7Tdo/SRluuW7hJkK9GECodA0GLLHoWD9JHCQbrbsTIhnhMJFQ7ltQECOitR+sqv5bqlGzMAVeucbkXUJVQ4bNCQkhyKdoWD7KVitdMtiLqECYfGdlN7Nsih0XLdsreaTa7fHTBhwkGFaDlkbQoH2YtlQqW7h5ZcHw6huQ2bdysc5BC1NzjdAolFLh9acn04GIZBbYtJY7vmNsghaq1zugUSi3ZtdvXe4q4PB4Btteo1yCGyLA0ryb5ZJlSudboVUePqcAgNKW2t1UJKIhIFO907tOTqcDAMg6Z2kz0tOktJDpGl544cwJ4t0N7sdCuiwtXhAOo1SD9puW45EMuCyjVOtyIqXB8OqjdIv5h6/shBuPSsJVeHQ5vfoloT36Q/ggoHOYjdW1251pKrw2FnfVC7/0r/BLVctxyMBbXbnG5ExLk6HCoaNF4s/ZRgm8rLIdpd7nQLIs6V4RA6hVXhIP3mwuECiQKFQ3wwDIP6VpMWnwaVpJ+0XLf0RkMFBNzVy3RlOABUNqrXIBHg4uURJIIsC/a4q+7g2nCo0pCSRIJLJzhJFOzZ6nQLIsp14RCqN2jvBokIraskvbXHXXUH14WDYRg0tJm0+lVvkAho03Ld0kt1OyHod7oVEeO6cADY3axeg0SIwkF6yzJdNd/BpeGgeoNESGu90y2QeLI7cnWHhQsXcu6553ZeNgyDO++8s8dtnn/+eQzD6HHdfffdx9SpU8nMzGTQoEFMmzaNu+66q8+/36XhoJ6DRIBlaW0l6Zso1h3S0tK46667qK2t3e9tHnjgAa6//nquueYaPv/8c95//31+8pOf0NTU99pZUn8aG6u0RLdEhupW0kd1O+3hJSPy77tPO+00NmzYwB133MGvfvWrfd7mxRdf5KKLLuK73/1u53WTJk06pN/nup5DQ5uJX6NKEglarlv6ygxA856o3LXX6+WXv/wl99xzD9u3b9/nbYqKiliyZAnl5f3vwbguHDSkJBGjcJBD0VgTtbs+77zzOPLII/nZz362z+//7Gc/Y9CgQYwePZoJEyawcOFCnnrqKUyz76+LrguHPQoHiRQt1x3X7njqHYy5N3Pd/a90Xvfzv71F6Q//QOa828i7+Jec9tOH+Wjdwc8weub9VZRdcQ+p595C2RX38NwHPfdw+Nu/P2fEwl8z+Bt38J833dLje1u2bGH8+PE0NETmzLe77rqLRx55hNWrw/eRGDZsGB9++CErV67kmmuuwe/3s2DBAubMmdPngHBfOLTo3Z5EiJbrjluffLmD+1/7lCNGF/a4fnzxEO794ddY+cereO9X32N04SDO+O9Hqanf/0z4D9ds5eK7/pdvzZ7K5/dcybdmT+Wiu57qDJVd9c18754X+PV3zuS1Wy/jkecW8fLLL3f+/BVXXMGdd95JTk5ORI7tpJNO4swzz+TGG2/c720mT57MVVddxd/+9jdef/11Xn/9dRYvXtyn3+O6cKhvUxFRIiSgcIhHTa3tXPLrp/nr1V8nLyu9x/fmzzqC044cw+FFg5k0qoDffm8ODS3trNhcud/7+90/l3D6tMP5r4tOonTEUP7ropM4derh/O6FJQBsqqwlNyONi0+awjHji5k9dWznu/q///3vpKSkcP7550f0GO+8805efPFFPvjgg4PetqysDIDm5r4tBeOqcAiYllZilcgJaLnueHTVn1/ma8eM57Qjxxzwdj5/gPtf/ZTczDSmlhTt93Yfrt3GGdPG9rjuzOlj+WCNPadhXHE+Le1+lm2sYE9jC5+s2cwRkyexZ88ebr75Zu69997+H9RepkyZwiWXXMI999zT4/orrriC2267jffff5/y8nKWLFnCZZddxtChQzn++OP79DtcFQ6N6jVIJPlanW6B9NETi1fy2cad3LHgtP3e5qWP15F1wS9IO/827n7+Q16/bQFDcjP3e/vK2iYKB2X1uK5wUBaVtfbcgbysdB750Xlc9ttnOPb6+7nslKmc+ZXj+PGPf8zVV1/N5s2bmTZtGpMnT+bpp5+OzIECt912W+daciGnnXYaS5Ys4cILL2T8+PHMmzePtLQ03nzzTfLz8/t0/66a59DYrmK0RJDCIa5sq6nn2r++wr9uXUBaSvJ+bzf7iBKW/+EKdjW08NfXlnLRXU/y0W++T8FeAdDdXpOQsSyrx8zk82aWcd7Mss6v3/7XK6xcuZJ7772XsWPH8o9//IOioiKOPfZYTjrpJAoKCg56PA8//PA+L4eMGjWKtraevdt58+Yxb968g953b7grHNRzkEjyaUXWeLJ0w06q65o56rq/dF4XNE3eWVXOvS99TPtzN+P1eshMS2Hs8HzGDs9nRukIxl3+Ox7412f810Un7fN+i/K6egkh1fXNFA7ad2+j3R/gyhtu5vEnn2HDhg0EAgFOPvlkAMaPH89HH33E2WefHaGjjh5XhUNDm3oOEkHayyGunDr1cFbee1WP6779++coPWwoN8w7Ea9336PoFvYL+v4cXzqC15dt5Efnzuy87l/LNjBz4sh93v62J97mrJnTmD59OsuWLSMQ6Lpvv99PMBgfZ1S6Khw0rCQR1dbodAukD7IzUpm816mrmakp5GenM3l0Ic1tPm5/cjHnHFfKsMHZ7G5o4U+vfMz2XQ1ceOLkzp+57DfPUJyfwx0LTwfg2nNmcNIND3LX0+/y9eNKeeGjtbyxfBPv/eq77G1VeTVPvvMFy/9uL29RWlqKx+PhgQceoKioiLVr13LMMcdE8VGIHFeFQ5OGlSSStFy3q3g9Bmu37+KRN59gV0ML+TkZHDOumHfv+i6TRnXVALbW1OPxdNUTZk4cyRM/uZCbHn+T/378LcYU5fHkDRdx3IQRPe7fsiy+f+8L3H35WWRadr0qPT2dhx9+mKuuuor29nbuvfdeiouLB+aA+8mw9i53x7HHP2nGdM3RyEDLSIYLpnUbR379N9pDWg5NUiqc+ROnW9EvrjmV1RewFAwSOZalYJBDF2iHQ1jPKJa4JhzaAkoGEYkh/vg+Fdo94aA9oyWi9HySflI4xAaFg0RUnA8JSAxQOMQGDStJRLnnPA1xSpzPsHdPOKjnIJGkvaOlv9RziA3qOUhEKRykv9RziA2B+JiRLvFCu8BJf6nnEBuCGiOWSAq0O90CiXcKh9gQ1MklEkl+hYP0k4aVYkNQHQeJJJ9WZJV+Us8hNphaO0MiqV1LZ0g/xflcGdeEg4aVpL96bPbVrhVZpZ/23j4uzrgnHNRxkH7q8b/cUutYO8QljPh+eY3v1ncT1LCS9FOKt9sXLXsca4e4hMIhNhhx3oUT5zW32xu2AGC4ah8scUKcvya5Jhw88f13kBjQbkJje0c4jJzmbGMk/qnnEBu8CgeJgFUVfgCsYWX2bl4ih0rhEBvUc5BIWF8TIGhaGEkpMHzywX9AZH80rBQbPEoHiZDtdR0LdY2c7mxDJL6p5xAblA0SKUu3ttuF6dwiyB3mdHMkXikcYoPCQSKlyQdNocL0CBWm5RBpWCk2eF1zJBILVld1FKaLJ4M3xeHWSFxSOMSGFJ2uJBG0ripUmE6F4ZOcbo7EI2+y0y3oF9eEQ2qSwkEia2d9qDCtoSU5BKlZTregX1wTDmnJCgeJrKXbOgrTg4ohp9Dp5ki8UTjEBvUcJNIa2qDZp8K0HCKFQ2xIUzhIFKytDBWmp8T9GLIMsLRsp1vQL64Jh1StkyZRsLoqgGlaGMlpMGyi082ReKKeQ2xIVc1BomRng2ZMSx8ZHkjNdLoV/eKacNCwkkTLZ1t9dmE6bwRkDXW6ORIPUuI7GMBF4eD1GKRpaEmioK7NosWvpbylD9Lie0gJXBQOAFlprjociSHrqgL2hcOOAI/ehchBxHm9AVwWDtmpGlqS6Piiwo9pWZCcrsK0HJzCIbZkp7rqcCTGVIYK05rzIAcT56exQpyGw89//nMMw+jxUVRURHZaV89h5+a13P3ji/jhKcP5wewibv3ObHZXbjvg/X7y1vP818VH8d0TB/NfFx/Fp2//s8f3P3j1SX509gSuPH0ET/zhpz2+V7OznJ9ccCStTQ2RO1CJKUu3+e3CdP4oyBridHMklrkgHOJ28HTSpEm88cYbnV97vV7Mjp5D1fZN/OL7Z3DyOZdx/uU/JT0rh52b15Gcsv9tHzes/Ig/3bSA87//3xw162yWvv0if7rxMn56/+uMmXwMjXW7ePCXV3H5f/+FocUl/Pb6eZRO/wpHnjgHgEd+dR0XXXUL6Vk50T1wcUxti0mr3yIjxYARR8KaNw76M5KgsuP/rLa4DYekpCSKiop6XNfiMwF45s+3MHXmGVx89S86v1dQXHLA+3vtiT8y6dhTOHvhjwEYvnAC65a9x2tP/JErf/Ew1Tu2kJGZw3GnXwDAxKNOYufmtRx54hw+fO0pkpJSOHr21yN5iBKDvqwOcORhKXDYVFj3bzCDTjdJYlF2/K/FFZfDSgDr169n+PDhlJSU8I1vfINNmzaRkeLBwOTzD16jaORY/uear/Mfc0Zzy3dmsXTxiwe8vw0rP2bycaf2uG7yjNPYsPIjAIpGjKG9rZXydZ/TVL+Hzas/Y8S4yTTV7+HZ+3/Bt/7zN1E7VokdX+zsKEynZEBhqdPNkViUkQdJ8b8HSFyGw3HHHcejjz7Ka6+9xl//+lcqKyuZOXMmu3fvhpZdtLU08dKjv2XK8afzn3/4J0edfDb33DCftZ+9u9/7rN9dRe7ggh7X5Q4uoH53FQCZOXlc/rP7uP+Wy7nlO7M44avfZMqM03jiDz/l9At/QM3OLfz3t2Zy4zeP4ZM3n4vq8YtzTKC60e6has6D7JNLVvDtUzgsXLiwswCcnJxMYWEhp59+Og8++CCmaXbebvTo0WEFY8MwuPPOOwHYsmULhmGwfPnyQ2r0WWedxbx585gyZQqnnXYaL7/8MgCPPPIIOR1lheknfY053/wPRo0/grkL/g9TTzyLt559oE+/x7IsjG67OR096xxu//vH/M8zKzjv8p+yZuk7bN+4ipPP/TZ/vmkhl/zoLq6+8288cPtVNOypPqRjk9j32baOGdNDSiBjsNPNkViTiOEAMGfOHCoqKtiyZQuLFi1i9uzZXHvttcydO5dAINB5u1tvvZWKiooeH1dffXVEGx+SmZnJlClTWL9+PaOKC/B6kxhe0rPLP3z0BHZXbd/vfeTmF1K/1wt6Q20NOXv1JkL8vnYe/dWPWPh//0DVtk0EgwFKp3+FYaPGUzRyLBtXfdr/A5OYtKvZpC2gGdOyHy6oN8AhhENqaipFRUUUFxczffp0brzxRl544QUWLVrEww8/3Hm77OxsioqKenxkZkZnvZH29nbWrFnDsGHDKBqURknZUVSWr+9xm8qt6xlSNGK/9zF2yrGs+uitHtd98dGbjJ1y3D5v/8KDd3LEzDMYXXoklhnEDHYVJoMBP6YKla62oTo0Y3qqvciaSEjOvt9QxpuIPKtPOeUUpk6dyrPPPhuJuzuoH//4xyxevJjNmzfz0UcfccEFF9DQ0MCCBQsYnOHhrEuv5aM3nuHt5x+iattGXv/fv7D8vUWcOu/yzvu47+eX89Qff9b59RkXX8kXH7/Jy4/+lp1b1vHyo79l9cf/5sxvXBX2+7dvWs3Hrz/L+d+/CYBho8ZjGAaL//kIy997lYryLymZeFT0HwhxzOehwnRqJhROcLo5EiuSUu2CtAtE7FTW0tJSVqxY0fn1DTfcwE033dTjNi+99BKzZs3q9+/avn073/zmN9m1axdDhw5lxowZLFmyhFGjRgEw+8yv09Lwe1565Dc8/tv/ZNjIcVx9x98Yf+TMzvvYU7UNj6crG8cdMYMrb3uYZ+67lWfuu42Cw0q48vZHGDP5mB6/27IsHrrjGub/6E5S0+2eUEpaOpfffB+P/s/1BHztXPrj3zC4YHi/j1Nil2lBTaNJYY7XHlqqXON0kyQWZLuj1wBgWJZl9fbGCxcupK6ujueffz7sexdffDFffPEFq1atYvTo0Vx66aUsXLiwx22Ki4tJT09ny5YtlJSUsGzZMo488sh+HkK4dza0sWWPhnUkugqyPMwpS7e/eOseaK1ztD0SA0YdDZPPcroVERGxnsOaNWsoKemaaDZkyBDGjh0bqbvvk/xMr8JBoq66yaTNb5KW7LF7D+v+7XSTxGkuOVMJIlRzeOutt1i5ciXz5s2LxN31W0G2CoQyMDbuUmFauskpOvht4kSfew7t7e1UVlYSDAapqqri1Vdf5Y477mDu3LlcdtllnbdrbGyksrKyx89mZGSQk9O19tC6devC7r+srIyUlP7NLszP9JDkgYB58NuK9MfyHX7KipIx0rKhYBxUhT+nJUEkpboqHPpcc3jkkUcAe22jvLw8pk6dyvz581mwYEFngXf06NGUl5eH/fwPfvAD/vKXv3TWHPZl8+bNjB49+hAOpac31rWxs15DSxJ9Z01MY2i2F6rXwydPON0ccUrhBDj6IqdbETF9Cod4snKnj2Xb/U43QxJAUbaHMyam2zPq3/oDtGnZ9oQ0+Sy7IO0Srh0kLcrxOt0ESRCVjSbtgY6lVrQRUOIacuCVn+ONa8MhP8OuO4gMhE27OnqpI6aCoe1qE076IMjMBxcNxLj25dPjMRiapd6DDIxl2zt2iUvPhaHOnMItDgr1Glz0xsC14QAwLMfVhycxJGDC7ubQUt7TnW2MDLyhhzvdgohz9atn8aC43ehO4tDyHT4ArIKxkBr/ewhLbxmQ7656A7g4HCzLIi/DQ1aqe7p5Ett21pv4AhaG4bH3mJbEkDsMUtKdbkXEuTYcQpv0jMhT3UEGzqbdocL0kYDemCQEFw4pgYvDIWSEhpZkAC3b1lGYzhjk2hcN2csQd/6dXR8OBdkeUpUPMkD8JuxpUWE6YSSlQN5hTrciKlwfDh7DUGFaBtTnnYXpcZCa5XBrJKqKJoLHnUPXrg8HgBGD3PnHk9i0vc7EF7QwPF57tVZxr8OOcLoFUZMQ4TA816vZ0jKgtuzuWMpbZy25V1oO5I921azo7hLiJTPZazBysIaWZOB8tt1nF6YzB7vyHHgBiqfYn100K7q7hAgHgDH5CgcZOL4A1LWGCtNajM+VXDykBAkUDkU5HjJT3JnwEptW7LDnPFhFpZCS4XBrJKJyh0HWENcOKUEChYNhGJSo9yADqLw2iF+FaXdy+ZASJFA4AIwZonCQgVW+J1SY1tCSaxgeGD7Z6VZEXcKEg2VZ5KZ7GJKZMIcsMeCzbR2F6ax8GDzK6eZIJAw9HFIznW5F1CXMK2VorSX1HmQgtQWgvk2FaVcpdnchOiRhwiGkZEgSyQl31OKklZ2F6YmQ7L7VOxNKUioUTnC6FQMi4V4mU7wGY4aq9yADZ/OeIIGgheFNcv3pj65XPAW8ifH6kXDhAFBamOx0EyTBbK1VYTruGQYcPsPpVgyYhAyHnDQPxVpvSQbQ0q0dhensoZA3wunmyKEoKoOMPKdbMWASMhwAJqr3IAOoNQANbR0TplSYjk9jjne6BQMqIcPBsiyG53rJTXfvBBaJPV9UdCzlPawMktIcbo30yZASe1a0i2dE7y0hwyF0Wqt6DzKQNu4KEjAtDG8yFLt/EpWrHD7T/uziGdF7S8hwCDl8SBJpiXHigcSI7aHCtHaJix85RfbEtwTqNUCCh0OSx2DSsBSnmyEJ5NPQjOmcQhhU7HRzpDfGJF6vARI8HAAmFKj3IAOnxQeN7SpMx430QTBsotOtcETCh0OSV70HGVirKjpmTA+bZG9QL7Hr8Bn2QnsJKDGPei/qPchAWl8TIGhaGEkpCbG6Z9xKyUjobV4VDqj3IANvR13QvjDyKGcbIvtXchx4E/eMRoVDB/UeZCAt3dZuF6Zzi+zz5yW2pGbb4ZDAFA4dkrwGk4er9yADo7EdmkKFaa23FHsmnJzQvQZQOPRQWpBEdlpina4mzllT1VGYLp6c8C9EMSW7AA470ulWOE7h0I3HY3D0CPUeZGCsrQoVplNh+CSnmyMhpacm3JyGfVE4dGNZFiPykhiWo4dFBsbO+lBhWjOmY8KQEigYm3CzofdFr4LdhNZcOnpkKnrfIAOhszA9qNieNS3OMQwoO6PrcoJTOOzFsizyMjyM1W5xMgAa2qDFp8J0TBh1tF1vUK8BUDiECfUeph2WQrL2A5IBECpM21tQqjDtiJQMGD/LvqxeA6Bw2K+0ZIOpxSpOS/StrgxgmhYkpyXsOj6Om3CK/fhLJ4XDAZQWJpGfqYdIoq+iQYVpx+QOS+hlMvZHr3wH4DEMZpak4lEvU6JsaWgp77wRkDXU6eYkDsMDk7+qoaR9UDgcQKg4PWmYxoEluupaLVr8Wsp7wI09EQYNVxF6HxQOBxAqTh8xPJlczZyWKPuyqmOXuMOOAI/Olou63GEw9iv2ZfUcwigcesHrMTi+RHMfJLq+qPBjWhYkp6swHW2eJDjyXPDoJXB/9Mj0gmVZFGR7mVCod3MSPRZQGSpMa85DdJWeAllDnG5FTFM49EL3uQ/Zqeo/SPQs3ea3C9P5oyAz3+nmuFP+6IRfjrs3FA59kOw1+MqYVA1PStTUtpi0qTAdPUmpMPUcp1sRFxQOfWBZFkOyvEwt1tlLEj3rqkOF6ang0TT9iJp0JqTnOt2KuKBw6IPQ8NKUYckUZuuhk+j4YmdHYTolAwpLnW6OexSV2oGr01Z7Ra9wh8Aw7OGlVNWnJQpMoLrRtL/Q0FJkpGbak91Ap632ksLhEGWkeDjh8FSnmyEu9VloxvSQEsgY7HRz4t+UuXZASK8pHA6RZVkcNiiJSUWqP0jk7Wo2aQuoMB0R42dB4XgNJ/WRwuEQdZ7eOiJZO8dJVGyo7jZj2tBz7JAMK4NxmgV9KPSM6yePYXDS2DSyNP9BIuzzUGE6NQsKJzjdnPiTU6TTVvtB4RABqUkGs8elkaRHUyLItKCmSYXpQ5KaCUdfpM2T+kEvZxGSl+HhxDEqUEtkLdvmsy8MHQPpgxxtS9zweOGoCzWfoZ8UDhFiWRYj85I0QU4iqrrJpM2v3kOfTP6qvS+GCtD9onCIkFCBempxCqPyNKtVImfjrm4zplWYPrCS4+xd3SxLBeh+0jMtCk44PJWhWXpoJTI+39GxGF9aNhSMc7o5sWvI4TDxNPuygqHf9AoWBUleg1PGp5Gbrieo9F/AhF0qTB9Y5mCYPk89qwjSIxklqUkGp01IIzNFASH9t2y7XZi2ho6FtByHWxNj0rLhmG9CcprTLXEVhUMUZaZ4OHVCmtZgkn6rbDRpD1h2bUsbAXVJzYLjvmX3HCSiFA5RNijdwynjNQdC+m/TLr99YcRUjamDvWrtcZdCljZFiga9ZEWZZVkMzfJy8thUPPp/ln5Ytr2jMJ2eC0PHOt0cZyWn28GQPdTplriWwiHKDMPAsiyKByXxlTEKCDl0ARN2N3cUphN5aCkpFY67BHIKnW6JqykcBkAoIEYNTlIPQvpl+Y6OwnThOEjNdrg1DkhKgWMvgdxhmuQWZQqHARIKiBF5Scwap4CQQ7Oz3sQXsDAMj117SCTeZPuspLxiTXIbAAqHARQKiMMGJTF7XCpePbflEGzaHSpMTwMS5EnkSYJjvgGDRyoYBojCYYB1r0HMHp+GV38B6aPl2zoK0xmDYOjhTjcn+jxee4XV/NEKhgGklyYHhAJieK5Xp7lKn/lMqG1JkMJ06KykoWMUDANML0sOCQXEsBwvZ05MIz1ZT3rpvc87C9Pj3bs3ckYezPy2hpIconBwUCgg8jO9nFWWRm6anvzSO9vqTPxBC8PjtVdrdZtBxXYwhCa4KRgGnMLBYaGlvrNSPcwpS6dAq7lKL23Z3bGUt9uGlopKYca33NsjihN6JYohqUkGp5emMWqw9oOQg1u63WcXpjMHQ36J082JjJLjYPoF2t4zBigcYozXY3Dy2DTKirRanxyYLwB1rS5ZytswYNIcKDtDQ0gxQuEQo44emcrxJSmaLCcHtGKHPefBKiq1F6KLR95kOOoiGH2M0y2RbhQOMcqyLMYNTWZOmfaEkP0rrw12K0wf4XRz+i41C2ZcBoXjtRxGjFE4xKjQmUxDMr18bVI6w3L0p5J9K98TKkxPd7YhfZU/Ck78HgwarlNVY5BecWJY6EymtGSDUyekMWmYinQS7rNtHYXprHx7TkCsMwwYP8vepCctu+s6iSkKhzjhMQyOGpHCyWNTNaNaemgLQH1bqDAd472H9FyYsQDGfUWBEOP0MhNHQst+z52czpBM/emky8rOwvREe8mJWFRUCl+5HAaPUH0hDugVJo6Ehply0jzMKUtjanFyoqzJKQexeU+QQNDC8CZB8RSnm9OTJwkmfxWOurAruNRriHkKhzjlMQymFqcwpyyN7FT9owlsre0oTMfS0FLWUDjhuzDqKKdbIn2kcIhjof2p505OZ+xQTZpLdEu3dhSms4dC3mFON8de1uPE70JOgdMtkUOgcIhjoWGmZK/BzJJUZo1L1equCaw1AA1tHWP5TvYe0nLsIaQj5moZjDimcHAJy7IYmZfE16ekM75AvYhEtaqiYynvYWWQlDawv9zwwOEz4OQr7OKzis5xzbAs/QXdqKYpyIeb26lr1Z830cw/OoMkjwFfLILyTwfml+aNgClfhWwNIbmFeg4u1L0WMX1EsuZFJJjtA1mYTsmAqefAzIV2MOi9pmuo55AAmtpNPir3saMu6HRTZABkpsD5UzPsmtT7D0Ddzij8FsMOn9LZ9umpWv7CdTQ4nQCyUj2cOj6NHXUBPt3mo15DTa7W7IOmdovstI4X8EiHQ+4we97CoOFd1ykYXEc9hwRhWRaGYWBaFuurA3y+w0dbwOlWSbSMH5rEjJJUrIAP4827IeDr/50mp8P4k2HU0XYYqLfgagqHBOUPWqyq8LO60k/AdLo1Eg2XHJ2B12PAypdh62eHfkfJ6XD48fZ+C0kpkWugxDSFQ4Jr9Vus3Onjy+oApp4JrjJrbCojBydBfQW89//6fgcpGVAyQ6GQoBQOAkCLz2RVhZ/1NQH1JFwiOxXOPaKjMP3uX6Ghsnc/mJJh9xRGHa1QSGAKB+mhzW+xpsrP2io/fp3cFPfOOyKd7DQPlC+FL1458I0VCtKNwkH2yRewWFftZ02lX4XrOFZamMSxo1KxAu0Yb9wNQX/4jRQKsg8KBzmgQNBi464A66r9mm0dpzoL0ytehG3Lu76RNcReLfWwIxUKEkbhIL1W1RBkXbWfrbVBFa/jyOxxqYzIS4K6HfDBw/a6R6OOgvzRTjdNYpjCQXolNE8C7DOc1tf4WV8doNmnp0+sy0mDr0/pKEy3N0Nqpv0NzVOQA1A4yCEzLYsddUE27QqwvS5IUM+kmOIxYGSel7FDkxmW4+kMd5HeUDhIRPiDFltrA2zeHaSiIaj11xxiGDAsx8uowV5G5iWRmqRAkEOjcJCIa/VblO8JsHl3gJomTZqIts5AyPMycrACQSJD4SBR1eIz2VEXZHt9kIr6oCbYRYjXA4XZCgSJHoWDDJigaVHdaLK9PsCOumDXlpbSK3npHobnehme66Ug22OfnioSJQoHcUxjm0llQ5DqJpPqxiCN7XoqdpeRYlCU7WVYrpfhOR7SU7RrkwwchYM4ovupsSGtfovqxiA1TUGqG032tJgJM58iyQP5mR6GZHkZmulhSJaHDIWBOEjhIDFhX2ERMC3qWkzqWk1qQ59bLdr88f2UTU82yE0zyE33kJfhYWiWl9x0A89ex7+vx0RkoCgcJO60+S3qWu2waGwzafZZ9ke7GTPrQKV47WGhrFQPuWkectPtMMhN85Ci4rHEAYWDxJWDvZsOmBYtPoumdosWn0mr38IXgPaARXvAwhe08AfBb9qfTdPCArDA6vwd9mUL8Br2kE+S1yDZa5AcutzxOTUJMlI8ZCQbpKcYZCQbZKQYBywWq0cg8UDhICIiYVTxEhGRMAoHEREJo3AQEZEwCgcREQmjcBARkTAKBxERCaNwEBGRMAoHEREJo3AQEZEwCgcREQmjcBARkTAKBxERCaNwEBGRMAoHEREJo3AQEZEwCgcREQmjcBARkTAKBxERCaNwEBGRMAoHEREJo3AQEZEwCgcREQmjcBARkTAKBxERCaNwEBGRMAoHEREJo3AQEZEwCgcREQmjcBARkTAKBxERCaNwEBGRMAoHEREJo3AQEZEwCgcREQmjcBARkTAKBxERCaNwEBGRMAoHEREJo3AQEZEwCgcREQmjcBARkTAKBxERCaNwEBGRMAoHEREJo3AQEZEwCgcREQmjcBARkTD/H3hWqZrjEMhKAAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 640x480 with 1 Axes>"
       ]
@@ -322,7 +322,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [
     {
@@ -360,15 +360,15 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>SV Length</th>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
+       "      <td>8357</td>\n",
+       "      <td>2692</td>\n",
+       "      <td>1895</td>\n",
+       "      <td>407</td>\n",
+       "      <td>509</td>\n",
+       "      <td>124</td>\n",
+       "      <td>49</td>\n",
+       "      <td>11</td>\n",
+       "      <td>5</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -376,13 +376,13 @@
       ],
       "text/plain": [
        "           50-100  100-300  300-500  0.5-1k  1k-5k  5k-10k  10k-100k  100k-1M  \\\n",
-       "SV Length       0        0        0       0      0       0         0        0   \n",
+       "SV Length    8357     2692     1895     407    509     124        49       11   \n",
        "\n",
        "           >1M  \n",
-       "SV Length    0  "
+       "SV Length    5  "
       ]
      },
-     "execution_count": 12,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/ugvc/reports/createSVReport.ipynb
+++ b/ugvc/reports/createSVReport.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-07-25T13:41:08.009132Z",
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 2,
    "metadata": {
     "tags": [
      "parameters"
@@ -37,7 +37,7 @@
    "source": [
     "run_id = \"NA\"\n",
     "pipeline_version = \"NA\"\n",
-    "statistics_file = \"/data/Runs/VariantCalling/work/250525/dragen.hg19.stats.pkl\"\n",
+    "statistics_file = \"/data/Runs/VariantCalling/work/251204/hg002.cnv.release.stats.pkl\"\n",
     "reference_version = \"hg38\"\n",
     "truth_sample_name = \"NA\"\n",
     "h5outfile = \"var_report.h5\"    \n"
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 3,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-07-25T13:41:08.938665Z",
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 4,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -119,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 5,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-07-25T13:41:11.945866Z",
@@ -154,7 +154,7 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>statistics_file</th>\n",
-       "      <td>dragen.hg19.stats.pkl</td>\n",
+       "      <td>hg002.cnv.release.stats.pkl</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>run_id</th>\n",
@@ -181,13 +181,13 @@
        "</div>"
       ],
       "text/plain": [
-       "                                   value\n",
-       "statistics_file    dragen.hg19.stats.pkl\n",
-       "run_id                                NA\n",
-       "reference_version                   hg38\n",
-       "pipeline_version                      NA\n",
-       "truth_sample_name                     NA\n",
-       "h5outfile                  var_report.h5"
+       "                                         value\n",
+       "statistics_file    hg002.cnv.release.stats.pkl\n",
+       "run_id                                      NA\n",
+       "reference_version                         hg38\n",
+       "pipeline_version                            NA\n",
+       "truth_sample_name                           NA\n",
+       "h5outfile                        var_report.h5"
       ]
      },
      "metadata": {},
@@ -203,7 +203,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -262,7 +262,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -273,7 +273,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -282,12 +282,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYcAAAGFCAYAAAAW1j91AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAAA7bUlEQVR4nO3dd3hc1b3u8e+eUa+WZUuyhYtwk2UbY9OMIWBTTWIIYEpiCHYKSYBDCTcn3EM4JEAIkJOEJJACuXSSAIcaiiGUYKopxsbGDVe5qdlWb1P2vn9sjYrHRbJmtGf2vJ/n0aPRaDRaezSad9b67bWWYVmWhYiISDcepxsgIiKxR+EgIiJhFA4iIhJG4SAiImEUDiIiEkbhICIiYRQOIiISRuEgIiJhFA4iIhJG4SAiImEUDiIiEkbhICIiYRQOIiISRuEgIiJhFA4iIhJG4SAiImEUDiIiEkbhICIiYRQOIiISRuEgIiJhFA4iIhJG4SAiImEUDiIiEkbhICIiYRQOIiISRuEgcgCzZs3iuuuuA2DhwoUYhoFhGHi93s7LoY+UlBTmzJmDYRg8//zz1NXVdV5fXl7Odddd1/m9c889l7Fjx4bdh2EYJCUlUVhYyOmnn86DDz6IaZrOPgiSkBQOIn0wZ84cKioquP/++wEYN24cKSkpGIaBaZrU1dXt8+duvvnmsOtM02TIkCGMGjWKOXPmcMQRR5CWlsb8+fNZtGgRs2fP5tprr2Xu3LkEAoFoHpZIGIWDSB+kpqZSVFREfn4+AGVlZVx77bVYlsXMmTNpaGgAoL6+vvNnzj//fB5//HF27drVeZ3f76eiogKfz8eHH35IYWEhJSUlXHrppbz++utMnz6dG2+8kRdeeIFFixbx8MMPD+hxiigcRPqprKwMj8eDYRisX78egOzs7M7vT548mblz5/L+++8DUFlZyXvvvYdlWZxwwgkMGzas87bp6en4/f7Or0855RSmTp3Ks88+O0BHI2JLcroBIvHspZdeYtGiRZimyTvvvENmZiaBQADLsnrc7o477mDy5MkAXHvttaSkpDB8+HBSUlI6b1NbW8t7773Hqaee2uNnS0tLWbFiRfQPRqQb9RxE+mH27NnceuutJCUlUVJSwjnnnAPAc8891+N2ZWVlTJw4EYCzzz6bpqYmGhoaeOmll8jKyuKxxx7jnXfe4aSTTuKee+7p8bOWZWEYxsAckEgHhYPIAeTk5PSoH4TU1dWRnJxMZmYmhYWFmKZJWVkZjz32GADPPPMMLS0tPX6mrKwMsIvY06ZNY/fu3Rx++OEsX76c8847j7PPPptnn32WgoKCHj+3Zs0aSkpKonSEIvumcBA5gNLSUj799NOw6z/55BNycnIAWL16NaZpMm/evM7TUYPBIL///e87b29ZFmvXrgXg8ccfp7i4mIKCAjZs2MCzzz5LVlYWHk/4v+Nbb73FypUrmTdvXpSOUGTfDGvvwVER6bRlyxbKysr49re/zbZt26irq+Oss87illtuYdKkSTQ2NlJeXo5pmixbtow///nP/OlPf8Lr9eLxePD7/Vx55ZUAPPTQQ7S2tpKRkYFpmhQXFzNo0CCWL1/O1KlTKSgo4KGHHiIYDFJVVcWrr77KHXfcwaxZs3j++efxer0OPxqSSBQOIgexdOlSfvrTn7J48WLa2toA8Hg8pKSkdH4N9hlKpaWl3HDDDfh8Pr7zne/Q1tZGZmYmJ554IrfffjtHH300l156KY8//jhjxoxh8uTJzJ8/n2984xudReykpCTy8vKYOnUq8+fPZ8GCBfvsVYhEk8JBRETC6O2IiIiEUTiIiEgYhYOIiIRROIiISBiFg4iIhFE4iIhIGIWDiIiEUTiIiEgYhYOIiIRROIiISBht9iOu1h6waPNb+IMW/iD4gl2X/UELvwlB08KyIMUL00ak2j/XCqnpHXfS1gpp9hcrmr/kiMzx9vUBH/iaISUDklIdODqR6FE4SNwKmhaNbRaN7SYtPotmn9Xx2f66xWcR7MPKYRnJXeGwZwcMGws01MOG9TD9aHb763ijfgkGBlMyx0Htdvj4b/YPe7yQnAGpmZAxCDLz7Y+swfbnlIyIH79INCkcJOYFTYuGNov6VpO6jo/6VpOGdvsdfzR0brxmWZBk/5sErSAAaZ6OrT39rV0/YAahvdH+aKgMv8PkdMjK7xYa+ZA5GDIGg3evf0PL6tYAEWcoHCTmNLSZ1DQFqWk0qWkyqWszoxYC+2OEqnGWBR37KPg7wiE1FA6+ln385H74W+2eRu32vX8TZA+FwSMgbyQMHgnpOf1rvEgEKBxkQO29H3LQtKhp6giDjs/tAQcb2KGziabZ2XMIWHbDUo2OcGhvisBvsqCx2v4oX2pflT7IDonQR1Z+BH6PSN8oHGRAGYZBfavJzvogO+qDVDUGCZpOt2of9jGsFNh7WCki4bAPrXWwow52rLC/Tsm0exahsMgp0rCTRJ3CQaLOH7SobLDDYGd9kKb22N9fqkfPoaMm4Av1HELh0NY4MI3xNUPlWvsD7KJ3YSkMmwj5o7qNgYlEjsJBosIftNhWG2TLngA764OYsZ8HPeyrIO23/EC3YaXWBgdaBrQ3w9al9kdKBhROgGFlkD8atJ2oRIjCQSImYFrsqAuyeXeAHfUxOlzUS51vxrvVHHymn1Qjpatm0lbvTOO687XAtmX2R3I6FE2AookwpMQ+vVbkEGkPaekXy7LYWR9k0+4A22qDBGIoEN58+n5eefz31O+uJDtvKMGAn5bGuh6Xh5dM5JIf3YVhGDz9p5up2fYlTU1NeDxePB4D0wwy6rAR/ODKK9nStpM/3PhrPB4Pp5xyCltWfUZ1fTPHji9mY8UeyqvrOff4ifzlyrmc8JMHeOMXC8jNTOOYH93HG79YwMiCQQN38MlpUDje7lEMHaOhJ+kzhYP0WvczjVp9Jut3BVhfHaDZF3tPoY9ef5r7fn45l/3kblqbGnjynpvwJiVx1qXX8dLDv8ablMT/uftZlr37Cov/+QhX/fJRgq31XH7OsWzZsoXn/vcV/v7UQ9x09dWMPLyE7//oetra2ig8fDg53kw2btzIOceO55ZLZjPtmj8zYmguF54wiRc/Xkd+TgbnHz+R6887gR/e+0/GF+dz/XknOPdgpOfCqKNhxJFdk/E0l0IOQm8npNcMw6CiPsjb69t4+vNWlm/3x2QwALz6j3s56ZzLmPX1hXz85rPMOu/bDC0ezbsvPtp5+YuP/80l1/+KwYXFrFv2ASfOuYhJkybxta99jf+584/MmTOHNevXc+n8+eTm5mJZFsefcxJJSUkEg0EKcjMpHJRF0LRoavVxx4LTmT5mOF/u2MW15xzP+6vL+XTDTq4953hnH4zWelj7Jrz5e1jxItRXKhjkoFRzkIPyBSzW1wT4stpPYxycaRTw+9iydhlfu+z6Hpc9Hi9vPn0/k487laSkFDasXALA5GNP7bwcsnLVMj744AN+cd11/PzOu6ipqSEjJ5NdWyrxeDwkJyfj8RikdEyQO3nyaJpafTy/ZA3XnjODoGlyxZ9e4sFrz8XrjZH3YGYAti23P/JGwOhj7PqEitiyDwoH6aH70FFzu8nqSj/rawIxVUs4mMa63ZjBILmDC3pcTsvIAiB3cAG5+QXUL6m2v+52+bDDDqOmpoZAIEBmZiZX3nwzfr+fa665hiGnj+J3l99B054G5p41h49Wf0rJ9+5mzLDBrN5WTf78O/B6PZiWxdjLf0dTq4/nPljDtfe/wq6GFq6eO4P/OPs4xx6XHmq32R+p2TDqKBg5DVLtx0dDTgIaVpIOodKTYRjUtZq8t7GdZ1e0sqYqvoKhu+4zsQ3D6HGMdgja3+t++d133+XTTz/l7l//Ba/XS0H+YC6ZP5/HH3+cyu07OXvBeUycOJFn//4I//jPCxmSk8HyP1yBgUF+dgZr/3w1v372fZrb/Cz9/Q/51TPvcdZR43n3ru9y6xNvs2LzPtZdclJ7I3z5Nrz1B1j+PDRUKxgEUM8h4YV6CoZhsKc5yIqdfrbWBp1uVr9kD8rH4/VSt7uK0aXTOi+3tzYDULe7ioY9NeQMLgDocbmkpASA0cOnUL27nNtvv50nnnwS0zT50xW/6QwWb84Qpowaym++N4egabJ6Ww1P/d+LGJydTtC0+PqMUvJzMgiYJukpSRQMyuLkyaNZ/MUWjigpcuaBORAzCDtWwo4voHgyjD8ZMvKcbpU4SD2HBBfqKfz7yzZeWtUW98EAkJScwujSaaz6+K0el9d8uphBQ4pY9fFbrPr4LcZOmQHQ43KIYUBKSgrDCwpYvnw5V155JbmFg7jguxczYcIEbv7xNYwqyOOc40p5+I3lAJwxbWzn5XHD8wl2zPzzBezH1B8MEjRjvRtm2SHx9p/gi0XQFqUlQiTmqeeQwJp9Jp9v97NxV4DYLzP3zZxv/gf3/fxySkqnc+yp53ecyprMWZdcw0uP/AYMg7w1n/G3u2+gavsmVnz4Lz6ddhyv/+UNlixZwgkzZvHY3x/kW+eczSeffMJjjz3GsQtPpiCrAK/Xy0N/f4r3fzGf6rom7n7hQ8YNH8ztTy7msX9/jmHApspa1m6rwWMYbKqs5cM1W3nz803ceOFJTj80vWOZUP4pbP8cRh8LY463J9lJwtA8hwTkC1isrPCztsof17OYD8aeBPc76nZVkjO4gKDfR3NjHTmDC2is3YXf386o8VPJyRtC1fZNpKamUlG+HtM0SU5OwTSDpKWkMHb8eL73ve/Rck4G2/6ygkf/+BC3/ej7/MdRWXzzV//LCRNHcuz4Yk6/6RECpskls47g3VXlVNc3M29mWefla8+Zwc3fnO30w3JoktJgzEwoORa8yU63RgaAwiEBhOoKQdNibZWflTv9+OJ/9CjiMpLhgmmZALQ0QEYOsHEDjBmLZVncXfEY3xhyFsNThsKG92Ddv51tsBNSs2DcV2DENHt5Dp3Z5FoaVkoAhmGwoy7AR+W+uFgRNRbs/XpndQy8pUV0L4c41N5k1yI2LYGyM+wlOsSVFA4u1+wz+aTc54pC80DqDIeOC2ZHOHQt152g4RDSUgufPmmv3TRpjr2MuHoRrqJwcJnQEJJpWaytCrB8uy9u5yk4qXOdus65EPaD2BkOTi3XHWsqVsOuzTDxNHvtJnENhYPLGIZBTVOQJZt91LYqFQ7ZPnoOSYaXJKNjGexYWK47Vvhb7TWbdn4BU76m+REuoXkOLhA6pyAQtPi4vJ1Fq9sUDP3UtdlPRzhYZtcmP5aVuDWHA9m1Gd65DzZ9aJ8KC/ZjJXFJPQcXMAyDXU1B3tvUTkOb/hkjoTMcOt4+BTG79o6W/Qv6Yc0bsHMVTJkLuTE4G1x6RT2HOGdaFsu3+1i0pk3BEEF7F6SDVrCr3mCpV3ZQ9RXw/gP2UuHBgNOtkUOgnkMcq2s1eX9TO7ub9WIVaV0bp4XCoduwkqkzv3rFMmHjB1C1Ho66ALKG6IymOKKeQ5xaU+nn5S9aFQxR0tVzsP9FAlaQNE+qfZ2pd8J90lQD7z0AO1crGOKIeg5xxhe0+GBTu+YtRFlXzcG+EOg+rBT0O9OoeBb0wbJnoHYrTDzdnl0tMU3hEAdCcxdqW0wWb1BtYSB0zXMIhUOga3Z0wOdMo9xgyydQtxOmz7P3ttYwU8zSsFIcMAyDTbsCLFrdqmAYaB0vXH4r0NVzUDj0T90OeO//Qc1GBUMMUzjEONO0+GhLO+9tatdMZyfsKxz8rQ42yCV8LfDxP+DLxZoLEaM0rBTDWnwmb29oZ1eTUsExHvv9k98KkB4qSCscIsSC9e/YPYkjz4WUDA0zxRD1HGJMaLZzbYvJK6vbFAxO63ih8ln+rp6Dr8XBBrlQzUZ49692LcIw1JOIEQqHGBIqPO+sD/Lq6lZafPoncVyo52D6u2ZIa+mMyGtrgCWPQvV6BUSMUDjEEMMwWF/t580v2/CrwxAbOk65bLf8XZPgEn257mgJ+u1lwLcu09BSDFDNIYZ8ts3HFxU6hz5mWBZ4O8LB9HXby6HRwUa5nGXBypfsnsT4k51uTUJTOMSAoGnxweZ2Nu/WxLaYk2SHQ4+zlVq1XHfUrX/HfpynzO0c2pOBpXBwWCBo8e/1bVQ0aBwpJiXZ/yIm3f4+bdroZ0Bs/xz8bTD9fPDopWqgKZId5A9avPmlgiGmefd6UbIsra00kKrWwcdPaOKhAxQODvEFLN5Y10ZVo4IhpnXUHKyOPaR1Fo0Ddm+Gjx7X/JIBpnBwQHvA4vV1bdRoDkP8sEKbSasu5Ii6HfDhYzqNeAApHAZYm9/iX2vbtNR2HLEsC0/o1Ert5eCcxipY8rgmIQ4QhcMAavVbvLa2ldoWBUO80XLdMaKpBj75h2oQA0DhMEB8AYs317VR36ox67jRbSJWmsIhdtTthKVPqRcXZQqHARAwLd5a38Ye9RjikoXVNTs60O5sY8S2azMse04nCESRwiHKTMvinQ3tVOuspLhlYnVbrlvhEDMq18DKl51uhWspHKLsg00+ttep+xvPLMvq2j9ap1PGlm3LYO2bTrfClRQOUfRxeTubdmvCVLwzMbuGlXSmTOzZ+IH9ARpmiiCFQ4SF9mNYsdPH2ioFgxuYltltue5mZxsj+7b2TbsXoeW+I0bhEEGh/Ri27A6wfLvOanGLIGZXzUGTsGLXypehcq0CIkIUDhFkGAY1TUHe36SipZsErW7DSlquO3ZZFix7tmtHOekXhUMENbebvL2+naDetLhK0Ap2DStpRdbYZgbhs6dVG4oAhUOEBEyLf69vp9WvZHAbCwuP0fGvor0cYl9rveZARIDCIUI+3NyuSW5uZ1k6lTVe7NoEX75tX1ZIHBKFQz+EzkxaVeHTLm4JQS8ycWXDe1D1peoPh0jh0A+GYVDdGOSzbTozKSHoHWj8Wf48NO9xuhVxSeHQD+0Bi3c3tuv9ZKLQDnDxJ9BuF6i1YGKfKRz64f1N7TT7FA1uZ9AxLBFUOMSlhipY+Yp9Wb2/XlM49FGozrCm0q81kxKEERqz1rvP+LVjBZR/qglyfaBw6CPDMNjdHGTpNm02kii6eg76m8e11f+C2h0qUPeSwqGP/EF7CW5Tbz4SRmc4aLnu+GYG7QK1eoC9onDopdBw0sflPhrblQyJxNMZDm3ONkT6r2UPfLnYvqzhpQNSOPSSYRhsrwuwcZeKkommc3a0X0syuMLmJVp/qRcUDr3kC1os2aIx50TU2XNoVzi4gmXBihe1B/VBKBwOIjSctHSrjxadtpqQOnsOWq7bPRqr7RnUsl8Kh4MwDIOK+iDrazSclKi8Cgd32vAeNFQ73YqYpXA4iEDQ4sMtOkslkXnx2hdatVy3q1gmrPin/VnCKBz2IzSc9Nl2H006OymhdU6C014O7lNfAZuWON2KmKRw2I/QZLd12gdaQtRzcKcvF0PzbqdbEXMUDvvQfU6D+gwCdJwTr+EHVzIDsOIlp1sRcxQO+2AYBpt3B6hp0ouBdNC4tLvt2QrbljvdipiicNiHQNBi6VbNaZBuFA7u9+VirbzbjcJhH1ZW+GnRXtDSnV403K+tAbZ87HQrYobCYS9N7SarK7Qwl+zF1HMiIWx8X/uEd1A4dAgVoT/d6iOoToPsLaBwSAj+NtjwvtOtiAkKhw6GYVDTFGRrrdZbkX0IaCJkwtjyiU5bRuEAdPUalm/Xu0PZDy3XnTjMAKzXst4KB+xeQ1VjkIoG9RpkPzQOnVi2fw6NNQm9rHfCh0NXr0GnrsoB+LRcd0KxLFj3VtflBJTw4WAYBpUNQaoadR67HEB7s9MtkIFW9SXs2ZawvYeEDgf1GqTXtFx3Ylr7pv05AXsPCR0OhmGwsz5ItZbJkINpb3S6BeKE2m2wa3NC9h4SNhxCvYYVO9VrkF5orXe6BeKUzYk5azphw8EwDHY1B6lWrUF6Q+GQuKrXQ/Mep1sx4BI2HADWVGpeg/SCZUFAPczEZdkT4xJMwoZDi8+kfI/mNUhvJF4xUvayfTn4E2uWfMKGw9qqAKb+56U3TA09JryAzw6IBJKQ4RAIWnxZrSEl6SVTPUzBHlpKoFNaEzIcNu4K4NP/u/SWlusWgJZauzidIBIqHEKnr66p0j+79EFQzxfpsPkj+3MC9CASKhxCC+w1tLn/DysRpDOVJGT3FmioTohJcQkVDgAba7Tdo/SRluuW7hJkK9GECodA0GLLHoWD9JHCQbrbsTIhnhMJFQ7ltQECOitR+sqv5bqlGzMAVeucbkXUJVQ4bNCQkhyKdoWD7KVitdMtiLqECYfGdlN7Nsih0XLdsreaTa7fHTBhwkGFaDlkbQoH2YtlQqW7h5ZcHw6huQ2bdysc5BC1NzjdAolFLh9acn04GIZBbYtJY7vmNsghaq1zugUSi3ZtdvXe4q4PB4Btteo1yCGyLA0ryb5ZJlSudboVUePqcAgNKW2t1UJKIhIFO907tOTqcDAMg6Z2kz0tOktJDpGl544cwJ4t0N7sdCuiwtXhAOo1SD9puW45EMuCyjVOtyIqXB8OqjdIv5h6/shBuPSsJVeHQ5vfoloT36Q/ggoHOYjdW1251pKrw2FnfVC7/0r/BLVctxyMBbXbnG5ExLk6HCoaNF4s/ZRgm8rLIdpd7nQLIs6V4RA6hVXhIP3mwuECiQKFQ3wwDIP6VpMWnwaVpJ+0XLf0RkMFBNzVy3RlOABUNqrXIBHg4uURJIIsC/a4q+7g2nCo0pCSRIJLJzhJFOzZ6nQLIsp14RCqN2jvBokIraskvbXHXXUH14WDYRg0tJm0+lVvkAho03Ld0kt1OyHod7oVEeO6cADY3axeg0SIwkF6yzJdNd/BpeGgeoNESGu90y2QeLI7cnWHhQsXcu6553ZeNgyDO++8s8dtnn/+eQzD6HHdfffdx9SpU8nMzGTQoEFMmzaNu+66q8+/36XhoJ6DRIBlaW0l6Zso1h3S0tK46667qK2t3e9tHnjgAa6//nquueYaPv/8c95//31+8pOf0NTU99pZUn8aG6u0RLdEhupW0kd1O+3hJSPy77tPO+00NmzYwB133MGvfvWrfd7mxRdf5KKLLuK73/1u53WTJk06pN/nup5DQ5uJX6NKEglarlv6ygxA856o3LXX6+WXv/wl99xzD9u3b9/nbYqKiliyZAnl5f3vwbguHDSkJBGjcJBD0VgTtbs+77zzOPLII/nZz362z+//7Gc/Y9CgQYwePZoJEyawcOFCnnrqKUyz76+LrguHPQoHiRQt1x3X7njqHYy5N3Pd/a90Xvfzv71F6Q//QOa828i7+Jec9tOH+Wjdwc8weub9VZRdcQ+p595C2RX38NwHPfdw+Nu/P2fEwl8z+Bt38J833dLje1u2bGH8+PE0NETmzLe77rqLRx55hNWrw/eRGDZsGB9++CErV67kmmuuwe/3s2DBAubMmdPngHBfOLTo3Z5EiJbrjluffLmD+1/7lCNGF/a4fnzxEO794ddY+cereO9X32N04SDO+O9Hqanf/0z4D9ds5eK7/pdvzZ7K5/dcybdmT+Wiu57qDJVd9c18754X+PV3zuS1Wy/jkecW8fLLL3f+/BVXXMGdd95JTk5ORI7tpJNO4swzz+TGG2/c720mT57MVVddxd/+9jdef/11Xn/9dRYvXtyn3+O6cKhvUxFRIiSgcIhHTa3tXPLrp/nr1V8nLyu9x/fmzzqC044cw+FFg5k0qoDffm8ODS3trNhcud/7+90/l3D6tMP5r4tOonTEUP7ropM4derh/O6FJQBsqqwlNyONi0+awjHji5k9dWznu/q///3vpKSkcP7550f0GO+8805efPFFPvjgg4PetqysDIDm5r4tBeOqcAiYllZilcgJaLnueHTVn1/ma8eM57Qjxxzwdj5/gPtf/ZTczDSmlhTt93Yfrt3GGdPG9rjuzOlj+WCNPadhXHE+Le1+lm2sYE9jC5+s2cwRkyexZ88ebr75Zu69997+H9RepkyZwiWXXMI999zT4/orrriC2267jffff5/y8nKWLFnCZZddxtChQzn++OP79DtcFQ6N6jVIJPlanW6B9NETi1fy2cad3LHgtP3e5qWP15F1wS9IO/827n7+Q16/bQFDcjP3e/vK2iYKB2X1uK5wUBaVtfbcgbysdB750Xlc9ttnOPb6+7nslKmc+ZXj+PGPf8zVV1/N5s2bmTZtGpMnT+bpp5+OzIECt912W+daciGnnXYaS5Ys4cILL2T8+PHMmzePtLQ03nzzTfLz8/t0/66a59DYrmK0RJDCIa5sq6nn2r++wr9uXUBaSvJ+bzf7iBKW/+EKdjW08NfXlnLRXU/y0W++T8FeAdDdXpOQsSyrx8zk82aWcd7Mss6v3/7XK6xcuZJ7772XsWPH8o9//IOioiKOPfZYTjrpJAoKCg56PA8//PA+L4eMGjWKtraevdt58+Yxb968g953b7grHNRzkEjyaUXWeLJ0w06q65o56rq/dF4XNE3eWVXOvS99TPtzN+P1eshMS2Hs8HzGDs9nRukIxl3+Ox7412f810Un7fN+i/K6egkh1fXNFA7ad2+j3R/gyhtu5vEnn2HDhg0EAgFOPvlkAMaPH89HH33E2WefHaGjjh5XhUNDm3oOEkHayyGunDr1cFbee1WP6779++coPWwoN8w7Ea9336PoFvYL+v4cXzqC15dt5Efnzuy87l/LNjBz4sh93v62J97mrJnTmD59OsuWLSMQ6Lpvv99PMBgfZ1S6Khw0rCQR1dbodAukD7IzUpm816mrmakp5GenM3l0Ic1tPm5/cjHnHFfKsMHZ7G5o4U+vfMz2XQ1ceOLkzp+57DfPUJyfwx0LTwfg2nNmcNIND3LX0+/y9eNKeeGjtbyxfBPv/eq77G1VeTVPvvMFy/9uL29RWlqKx+PhgQceoKioiLVr13LMMcdE8VGIHFeFQ5OGlSSStFy3q3g9Bmu37+KRN59gV0ML+TkZHDOumHfv+i6TRnXVALbW1OPxdNUTZk4cyRM/uZCbHn+T/378LcYU5fHkDRdx3IQRPe7fsiy+f+8L3H35WWRadr0qPT2dhx9+mKuuuor29nbuvfdeiouLB+aA+8mw9i53x7HHP2nGdM3RyEDLSIYLpnUbR379N9pDWg5NUiqc+ROnW9EvrjmV1RewFAwSOZalYJBDF2iHQ1jPKJa4JhzaAkoGEYkh/vg+Fdo94aA9oyWi9HySflI4xAaFg0RUnA8JSAxQOMQGDStJRLnnPA1xSpzPsHdPOKjnIJGkvaOlv9RziA3qOUhEKRykv9RziA2B+JiRLvFCu8BJf6nnEBuCGiOWSAq0O90CiXcKh9gQ1MklEkl+hYP0k4aVYkNQHQeJJJ9WZJV+Us8hNphaO0MiqV1LZ0g/xflcGdeEg4aVpL96bPbVrhVZpZ/23j4uzrgnHNRxkH7q8b/cUutYO8QljPh+eY3v1ncT1LCS9FOKt9sXLXsca4e4hMIhNhhx3oUT5zW32xu2AGC4ah8scUKcvya5Jhw88f13kBjQbkJje0c4jJzmbGMk/qnnEBu8CgeJgFUVfgCsYWX2bl4ih0rhEBvUc5BIWF8TIGhaGEkpMHzywX9AZH80rBQbPEoHiZDtdR0LdY2c7mxDJL6p5xAblA0SKUu3ttuF6dwiyB3mdHMkXikcYoPCQSKlyQdNocL0CBWm5RBpWCk2eF1zJBILVld1FKaLJ4M3xeHWSFxSOMSGFJ2uJBG0ripUmE6F4ZOcbo7EI2+y0y3oF9eEQ2qSwkEia2d9qDCtoSU5BKlZTregX1wTDmnJCgeJrKXbOgrTg4ohp9Dp5ki8UTjEBvUcJNIa2qDZp8K0HCKFQ2xIUzhIFKytDBWmp8T9GLIMsLRsp1vQL64Jh1StkyZRsLoqgGlaGMlpMGyi082ReKKeQ2xIVc1BomRng2ZMSx8ZHkjNdLoV/eKacNCwkkTLZ1t9dmE6bwRkDXW6ORIPUuI7GMBF4eD1GKRpaEmioK7NosWvpbylD9Lie0gJXBQOAFlprjociSHrqgL2hcOOAI/ehchBxHm9AVwWDtmpGlqS6Piiwo9pWZCcrsK0HJzCIbZkp7rqcCTGVIYK05rzIAcT56exQpyGw89//nMMw+jxUVRURHZaV89h5+a13P3ji/jhKcP5wewibv3ObHZXbjvg/X7y1vP818VH8d0TB/NfFx/Fp2//s8f3P3j1SX509gSuPH0ET/zhpz2+V7OznJ9ccCStTQ2RO1CJKUu3+e3CdP4oyBridHMklrkgHOJ28HTSpEm88cYbnV97vV7Mjp5D1fZN/OL7Z3DyOZdx/uU/JT0rh52b15Gcsv9tHzes/Ig/3bSA87//3xw162yWvv0if7rxMn56/+uMmXwMjXW7ePCXV3H5f/+FocUl/Pb6eZRO/wpHnjgHgEd+dR0XXXUL6Vk50T1wcUxti0mr3yIjxYARR8KaNw76M5KgsuP/rLa4DYekpCSKiop6XNfiMwF45s+3MHXmGVx89S86v1dQXHLA+3vtiT8y6dhTOHvhjwEYvnAC65a9x2tP/JErf/Ew1Tu2kJGZw3GnXwDAxKNOYufmtRx54hw+fO0pkpJSOHr21yN5iBKDvqwOcORhKXDYVFj3bzCDTjdJYlF2/K/FFZfDSgDr169n+PDhlJSU8I1vfINNmzaRkeLBwOTzD16jaORY/uear/Mfc0Zzy3dmsXTxiwe8vw0rP2bycaf2uG7yjNPYsPIjAIpGjKG9rZXydZ/TVL+Hzas/Y8S4yTTV7+HZ+3/Bt/7zN1E7VokdX+zsKEynZEBhqdPNkViUkQdJ8b8HSFyGw3HHHcejjz7Ka6+9xl//+lcqKyuZOXMmu3fvhpZdtLU08dKjv2XK8afzn3/4J0edfDb33DCftZ+9u9/7rN9dRe7ggh7X5Q4uoH53FQCZOXlc/rP7uP+Wy7nlO7M44avfZMqM03jiDz/l9At/QM3OLfz3t2Zy4zeP4ZM3n4vq8YtzTKC60e6has6D7JNLVvDtUzgsXLiwswCcnJxMYWEhp59+Og8++CCmaXbebvTo0WEFY8MwuPPOOwHYsmULhmGwfPnyQ2r0WWedxbx585gyZQqnnXYaL7/8MgCPPPIIOR1lheknfY053/wPRo0/grkL/g9TTzyLt559oE+/x7IsjG67OR096xxu//vH/M8zKzjv8p+yZuk7bN+4ipPP/TZ/vmkhl/zoLq6+8288cPtVNOypPqRjk9j32baOGdNDSiBjsNPNkViTiOEAMGfOHCoqKtiyZQuLFi1i9uzZXHvttcydO5dAINB5u1tvvZWKiooeH1dffXVEGx+SmZnJlClTWL9+PaOKC/B6kxhe0rPLP3z0BHZXbd/vfeTmF1K/1wt6Q20NOXv1JkL8vnYe/dWPWPh//0DVtk0EgwFKp3+FYaPGUzRyLBtXfdr/A5OYtKvZpC2gGdOyHy6oN8AhhENqaipFRUUUFxczffp0brzxRl544QUWLVrEww8/3Hm77OxsioqKenxkZkZnvZH29nbWrFnDsGHDKBqURknZUVSWr+9xm8qt6xlSNGK/9zF2yrGs+uitHtd98dGbjJ1y3D5v/8KDd3LEzDMYXXoklhnEDHYVJoMBP6YKla62oTo0Y3qqvciaSEjOvt9QxpuIPKtPOeUUpk6dyrPPPhuJuzuoH//4xyxevJjNmzfz0UcfccEFF9DQ0MCCBQsYnOHhrEuv5aM3nuHt5x+iattGXv/fv7D8vUWcOu/yzvu47+eX89Qff9b59RkXX8kXH7/Jy4/+lp1b1vHyo79l9cf/5sxvXBX2+7dvWs3Hrz/L+d+/CYBho8ZjGAaL//kIy997lYryLymZeFT0HwhxzOehwnRqJhROcLo5EiuSUu2CtAtE7FTW0tJSVqxY0fn1DTfcwE033dTjNi+99BKzZs3q9+/avn073/zmN9m1axdDhw5lxowZLFmyhFGjRgEw+8yv09Lwe1565Dc8/tv/ZNjIcVx9x98Yf+TMzvvYU7UNj6crG8cdMYMrb3uYZ+67lWfuu42Cw0q48vZHGDP5mB6/27IsHrrjGub/6E5S0+2eUEpaOpfffB+P/s/1BHztXPrj3zC4YHi/j1Nil2lBTaNJYY7XHlqqXON0kyQWZLuj1wBgWJZl9fbGCxcupK6ujueffz7sexdffDFffPEFq1atYvTo0Vx66aUsXLiwx22Ki4tJT09ny5YtlJSUsGzZMo488sh+HkK4dza0sWWPhnUkugqyPMwpS7e/eOseaK1ztD0SA0YdDZPPcroVERGxnsOaNWsoKemaaDZkyBDGjh0bqbvvk/xMr8JBoq66yaTNb5KW7LF7D+v+7XSTxGkuOVMJIlRzeOutt1i5ciXz5s2LxN31W0G2CoQyMDbuUmFauskpOvht4kSfew7t7e1UVlYSDAapqqri1Vdf5Y477mDu3LlcdtllnbdrbGyksrKyx89mZGSQk9O19tC6devC7r+srIyUlP7NLszP9JDkgYB58NuK9MfyHX7KipIx0rKhYBxUhT+nJUEkpboqHPpcc3jkkUcAe22jvLw8pk6dyvz581mwYEFngXf06NGUl5eH/fwPfvAD/vKXv3TWHPZl8+bNjB49+hAOpac31rWxs15DSxJ9Z01MY2i2F6rXwydPON0ccUrhBDj6IqdbETF9Cod4snKnj2Xb/U43QxJAUbaHMyam2zPq3/oDtGnZ9oQ0+Sy7IO0Srh0kLcrxOt0ESRCVjSbtgY6lVrQRUOIacuCVn+ONa8MhP8OuO4gMhE27OnqpI6aCoe1qE076IMjMBxcNxLj25dPjMRiapd6DDIxl2zt2iUvPhaHOnMItDgr1Glz0xsC14QAwLMfVhycxJGDC7ubQUt7TnW2MDLyhhzvdgohz9atn8aC43ehO4tDyHT4ArIKxkBr/ewhLbxmQ7656A7g4HCzLIi/DQ1aqe7p5Ett21pv4AhaG4bH3mJbEkDsMUtKdbkXEuTYcQpv0jMhT3UEGzqbdocL0kYDemCQEFw4pgYvDIWSEhpZkAC3b1lGYzhjk2hcN2csQd/6dXR8OBdkeUpUPMkD8JuxpUWE6YSSlQN5hTrciKlwfDh7DUGFaBtTnnYXpcZCa5XBrJKqKJoLHnUPXrg8HgBGD3PnHk9i0vc7EF7QwPF57tVZxr8OOcLoFUZMQ4TA816vZ0jKgtuzuWMpbZy25V1oO5I921azo7hLiJTPZazBysIaWZOB8tt1nF6YzB7vyHHgBiqfYn100K7q7hAgHgDH5CgcZOL4A1LWGCtNajM+VXDykBAkUDkU5HjJT3JnwEptW7LDnPFhFpZCS4XBrJKJyh0HWENcOKUEChYNhGJSo9yADqLw2iF+FaXdy+ZASJFA4AIwZonCQgVW+J1SY1tCSaxgeGD7Z6VZEXcKEg2VZ5KZ7GJKZMIcsMeCzbR2F6ax8GDzK6eZIJAw9HFIznW5F1CXMK2VorSX1HmQgtQWgvk2FaVcpdnchOiRhwiGkZEgSyQl31OKklZ2F6YmQ7L7VOxNKUioUTnC6FQMi4V4mU7wGY4aq9yADZ/OeIIGgheFNcv3pj65XPAW8ifH6kXDhAFBamOx0EyTBbK1VYTruGQYcPsPpVgyYhAyHnDQPxVpvSQbQ0q0dhensoZA3wunmyKEoKoOMPKdbMWASMhwAJqr3IAOoNQANbR0TplSYjk9jjne6BQMqIcPBsiyG53rJTXfvBBaJPV9UdCzlPawMktIcbo30yZASe1a0i2dE7y0hwyF0Wqt6DzKQNu4KEjAtDG8yFLt/EpWrHD7T/uziGdF7S8hwCDl8SBJpiXHigcSI7aHCtHaJix85RfbEtwTqNUCCh0OSx2DSsBSnmyEJ5NPQjOmcQhhU7HRzpDfGJF6vARI8HAAmFKj3IAOnxQeN7SpMx430QTBsotOtcETCh0OSV70HGVirKjpmTA+bZG9QL7Hr8Bn2QnsJKDGPei/qPchAWl8TIGhaGEkpCbG6Z9xKyUjobV4VDqj3IANvR13QvjDyKGcbIvtXchx4E/eMRoVDB/UeZCAt3dZuF6Zzi+zz5yW2pGbb4ZDAFA4dkrwGk4er9yADo7EdmkKFaa23FHsmnJzQvQZQOPRQWpBEdlpina4mzllT1VGYLp6c8C9EMSW7AA470ulWOE7h0I3HY3D0CPUeZGCsrQoVplNh+CSnmyMhpacm3JyGfVE4dGNZFiPykhiWo4dFBsbO+lBhWjOmY8KQEigYm3CzofdFr4LdhNZcOnpkKnrfIAOhszA9qNieNS3OMQwoO6PrcoJTOOzFsizyMjyM1W5xMgAa2qDFp8J0TBh1tF1vUK8BUDiECfUeph2WQrL2A5IBECpM21tQqjDtiJQMGD/LvqxeA6Bw2K+0ZIOpxSpOS/StrgxgmhYkpyXsOj6Om3CK/fhLJ4XDAZQWJpGfqYdIoq+iQYVpx+QOS+hlMvZHr3wH4DEMZpak4lEvU6JsaWgp77wRkDXU6eYkDsMDk7+qoaR9UDgcQKg4PWmYxoEluupaLVr8Wsp7wI09EQYNVxF6HxQOBxAqTh8xPJlczZyWKPuyqmOXuMOOAI/Olou63GEw9iv2ZfUcwigcesHrMTi+RHMfJLq+qPBjWhYkp6swHW2eJDjyXPDoJXB/9Mj0gmVZFGR7mVCod3MSPRZQGSpMa85DdJWeAllDnG5FTFM49EL3uQ/Zqeo/SPQs3ea3C9P5oyAz3+nmuFP+6IRfjrs3FA59kOw1+MqYVA1PStTUtpi0qTAdPUmpMPUcp1sRFxQOfWBZFkOyvEwt1tlLEj3rqkOF6ang0TT9iJp0JqTnOt2KuKBw6IPQ8NKUYckUZuuhk+j4YmdHYTolAwpLnW6OexSV2oGr01Z7Ra9wh8Aw7OGlVNWnJQpMoLrRtL/Q0FJkpGbak91Ap632ksLhEGWkeDjh8FSnmyEu9VloxvSQEsgY7HRz4t+UuXZASK8pHA6RZVkcNiiJSUWqP0jk7Wo2aQuoMB0R42dB4XgNJ/WRwuEQdZ7eOiJZO8dJVGyo7jZj2tBz7JAMK4NxmgV9KPSM6yePYXDS2DSyNP9BIuzzUGE6NQsKJzjdnPiTU6TTVvtB4RABqUkGs8elkaRHUyLItKCmSYXpQ5KaCUdfpM2T+kEvZxGSl+HhxDEqUEtkLdvmsy8MHQPpgxxtS9zweOGoCzWfoZ8UDhFiWRYj85I0QU4iqrrJpM2v3kOfTP6qvS+GCtD9onCIkFCBempxCqPyNKtVImfjrm4zplWYPrCS4+xd3SxLBeh+0jMtCk44PJWhWXpoJTI+39GxGF9aNhSMc7o5sWvI4TDxNPuygqHf9AoWBUleg1PGp5Gbrieo9F/AhF0qTB9Y5mCYPk89qwjSIxklqUkGp01IIzNFASH9t2y7XZi2ho6FtByHWxNj0rLhmG9CcprTLXEVhUMUZaZ4OHVCmtZgkn6rbDRpD1h2bUsbAXVJzYLjvmX3HCSiFA5RNijdwynjNQdC+m/TLr99YcRUjamDvWrtcZdCljZFiga9ZEWZZVkMzfJy8thUPPp/ln5Ytr2jMJ2eC0PHOt0cZyWn28GQPdTplriWwiHKDMPAsiyKByXxlTEKCDl0ARN2N3cUphN5aCkpFY67BHIKnW6JqykcBkAoIEYNTlIPQvpl+Y6OwnThOEjNdrg1DkhKgWMvgdxhmuQWZQqHARIKiBF5Scwap4CQQ7Oz3sQXsDAMj117SCTeZPuspLxiTXIbAAqHARQKiMMGJTF7XCpePbflEGzaHSpMTwMS5EnkSYJjvgGDRyoYBojCYYB1r0HMHp+GV38B6aPl2zoK0xmDYOjhTjcn+jxee4XV/NEKhgGklyYHhAJieK5Xp7lKn/lMqG1JkMJ06KykoWMUDANML0sOCQXEsBwvZ05MIz1ZT3rpvc87C9Pj3bs3ckYezPy2hpIconBwUCgg8jO9nFWWRm6anvzSO9vqTPxBC8PjtVdrdZtBxXYwhCa4KRgGnMLBYaGlvrNSPcwpS6dAq7lKL23Z3bGUt9uGlopKYca33NsjihN6JYohqUkGp5emMWqw9oOQg1u63WcXpjMHQ36J082JjJLjYPoF2t4zBigcYozXY3Dy2DTKirRanxyYLwB1rS5ZytswYNIcKDtDQ0gxQuEQo44emcrxJSmaLCcHtGKHPefBKiq1F6KLR95kOOoiGH2M0y2RbhQOMcqyLMYNTWZOmfaEkP0rrw12K0wf4XRz+i41C2ZcBoXjtRxGjFE4xKjQmUxDMr18bVI6w3L0p5J9K98TKkxPd7YhfZU/Ck78HgwarlNVY5BecWJY6EymtGSDUyekMWmYinQS7rNtHYXprHx7TkCsMwwYP8vepCctu+s6iSkKhzjhMQyOGpHCyWNTNaNaemgLQH1bqDAd472H9FyYsQDGfUWBEOP0MhNHQst+z52czpBM/emky8rOwvREe8mJWFRUCl+5HAaPUH0hDugVJo6Ehply0jzMKUtjanFyoqzJKQexeU+QQNDC8CZB8RSnm9OTJwkmfxWOurAruNRriHkKhzjlMQymFqcwpyyN7FT9owlsre0oTMfS0FLWUDjhuzDqKKdbIn2kcIhjof2p505OZ+xQTZpLdEu3dhSms4dC3mFON8de1uPE70JOgdMtkUOgcIhjoWGmZK/BzJJUZo1L1equCaw1AA1tHWP5TvYe0nLsIaQj5moZjDimcHAJy7IYmZfE16ekM75AvYhEtaqiYynvYWWQlDawv9zwwOEz4OQr7OKzis5xzbAs/QXdqKYpyIeb26lr1Z830cw/OoMkjwFfLILyTwfml+aNgClfhWwNIbmFeg4u1L0WMX1EsuZFJJjtA1mYTsmAqefAzIV2MOi9pmuo55AAmtpNPir3saMu6HRTZABkpsD5UzPsmtT7D0Ddzij8FsMOn9LZ9umpWv7CdTQ4nQCyUj2cOj6NHXUBPt3mo15DTa7W7IOmdovstI4X8EiHQ+4we97CoOFd1ykYXEc9hwRhWRaGYWBaFuurA3y+w0dbwOlWSbSMH5rEjJJUrIAP4827IeDr/50mp8P4k2HU0XYYqLfgagqHBOUPWqyq8LO60k/AdLo1Eg2XHJ2B12PAypdh62eHfkfJ6XD48fZ+C0kpkWugxDSFQ4Jr9Vus3Onjy+oApp4JrjJrbCojBydBfQW89//6fgcpGVAyQ6GQoBQOAkCLz2RVhZ/1NQH1JFwiOxXOPaKjMP3uX6Ghsnc/mJJh9xRGHa1QSGAKB+mhzW+xpsrP2io/fp3cFPfOOyKd7DQPlC+FL1458I0VCtKNwkH2yRewWFftZ02lX4XrOFZamMSxo1KxAu0Yb9wNQX/4jRQKsg8KBzmgQNBi464A66r9mm0dpzoL0ytehG3Lu76RNcReLfWwIxUKEkbhIL1W1RBkXbWfrbVBFa/jyOxxqYzIS4K6HfDBw/a6R6OOgvzRTjdNYpjCQXolNE8C7DOc1tf4WV8doNmnp0+sy0mDr0/pKEy3N0Nqpv0NzVOQA1A4yCEzLYsddUE27QqwvS5IUM+kmOIxYGSel7FDkxmW4+kMd5HeUDhIRPiDFltrA2zeHaSiIaj11xxiGDAsx8uowV5G5iWRmqRAkEOjcJCIa/VblO8JsHl3gJomTZqIts5AyPMycrACQSJD4SBR1eIz2VEXZHt9kIr6oCbYRYjXA4XZCgSJHoWDDJigaVHdaLK9PsCOumDXlpbSK3npHobnehme66Ug22OfnioSJQoHcUxjm0llQ5DqJpPqxiCN7XoqdpeRYlCU7WVYrpfhOR7SU7RrkwwchYM4ovupsSGtfovqxiA1TUGqG032tJgJM58iyQP5mR6GZHkZmulhSJaHDIWBOEjhIDFhX2ERMC3qWkzqWk1qQ59bLdr88f2UTU82yE0zyE33kJfhYWiWl9x0A89ex7+vx0RkoCgcJO60+S3qWu2waGwzafZZ9ke7GTPrQKV47WGhrFQPuWkectPtMMhN85Ci4rHEAYWDxJWDvZsOmBYtPoumdosWn0mr38IXgPaARXvAwhe08AfBb9qfTdPCArDA6vwd9mUL8Br2kE+S1yDZa5AcutzxOTUJMlI8ZCQbpKcYZCQbZKQYBywWq0cg8UDhICIiYVTxEhGRMAoHEREJo3AQEZEwCgcREQmjcBARkTAKBxERCaNwEBGRMAoHEREJo3AQEZEwCgcREQmjcBARkTAKBxERCaNwEBGRMAoHEREJo3AQEZEwCgcREQmjcBARkTAKBxERCaNwEBGRMAoHEREJo3AQEZEwCgcREQmjcBARkTAKBxERCaNwEBGRMAoHEREJo3AQEZEwCgcREQmjcBARkTAKBxERCaNwEBGRMAoHEREJo3AQEZEwCgcREQmjcBARkTAKBxERCaNwEBGRMAoHEREJo3AQEZEwCgcREQmjcBARkTAKBxERCaNwEBGRMAoHEREJo3AQEZEwCgcREQmjcBARkTD/H3hWqZrjEMhKAAAAAElFTkSuQmCC",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAGFCAYAAAASI+9IAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAE4ElEQVR4nO3VMQHAMAzAsKz8OWefKbSHhMCfv93dAYCZObcDAHiHKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBAfu8DBwYENNNsAAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 640x480 with 1 Axes>"
       ]
@@ -322,7 +322,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -360,15 +360,15 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>SV Length</th>\n",
-       "      <td>8357</td>\n",
-       "      <td>2692</td>\n",
-       "      <td>1895</td>\n",
-       "      <td>407</td>\n",
-       "      <td>509</td>\n",
-       "      <td>124</td>\n",
-       "      <td>49</td>\n",
-       "      <td>11</td>\n",
-       "      <td>5</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -376,13 +376,13 @@
       ],
       "text/plain": [
        "           50-100  100-300  300-500  0.5-1k  1k-5k  5k-10k  10k-100k  100k-1M  \\\n",
-       "SV Length    8357     2692     1895     407    509     124        49       11   \n",
+       "SV Length       0        0        0       0      0       0         0        0   \n",
        "\n",
        "           >1M  \n",
-       "SV Length    5  "
+       "SV Length    0  "
       ]
      },
-     "execution_count": 50,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/ugvc/reports/var_report.h5
+++ b/ugvc/reports/var_report.h5
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5c136117abf7e8ca6a74f177b4d8ac025ee70e97091e1b84b4f06e25fde0b90b
-size 2121927

--- a/ugvc/reports/var_report.h5
+++ b/ugvc/reports/var_report.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c136117abf7e8ca6a74f177b4d8ac025ee70e97091e1b84b4f06e25fde0b90b
+size 2121927


### PR DESCRIPTION
Fix imports / fix filtering

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fix SV stats filtering to accept PASS/empty/'.', drop CNV pipelines/scripts from CLI, and switch BED base counting to BedUtils across code/tests.
> 
> - **SV stats (`ugvc/pipelines/sv_stats_collect.py`)**:
>   - Relax FILTER logic to include `PASS`, empty, or `.` when `ignore_filter` is False.
>   - Ensure length-by-type table is consistently shaped and safely drop `CTX` if present.
> - **CLI/Packaging**:
>   - Remove CNV-related pipelines from `ugvc/__main__.py` module registry.
>   - Prune CNV scripts from `setup.py` `scripts` list.
> - **Pipelines**:
>   - `run_no_gt_report.py`: use `ugbio_core.bed_utils.BedUtils().count_bases_in_bed_file` for callable region size.
> - **Tests**:
>   - Update BED base counting to `BedUtils` in `test_gvcf_bed.py`.
>   - Adjust mock VCF `FILTER` to `.` in `test_sv_stats_collect.py` to align with new filtering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03d4154460aac62d040e5f2ac74799530b12de67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->